### PR TITLE
chore(deps): bump uvicorn, asyncpg, python-multipart

### DIFF
--- a/requirements.nori.txt
+++ b/requirements.nori.txt
@@ -2,14 +2,14 @@
 # This file is owned by the framework and regenerated on every `framework:update`.
 # Your site's dependencies go in requirements.txt, which already `-r`s this file.
 starlette>=1.0.0
-uvicorn[standard]>=0.29
+uvicorn[standard]>=0.46.0
 tortoise-orm>=0.25,<1.0  # aerich 0.9.x incompatible with tortoise 1.x — revisit when aerich drops the <1.0 pin
 aerich>=0.8
 tomlkit>=0.13         # used by aerich for migrate:init / pyproject.toml; not declared as a transitive dep
 asyncmy>=0.2
-asyncpg>=0.29
+asyncpg>=0.31.0
 jinja2>=3.1.6
-python-multipart>=0.0.26
+python-multipart>=0.0.27
 python-dotenv>=1.2.2
 httpx>=0.27
 itsdangerous>=2.2.0


### PR DESCRIPTION
## Summary

Batches three Dependabot PRs that all touched `requirements.nori.txt` to avoid rebase churn from sequential merges.

- `uvicorn[standard]` `>=0.29` → `>=0.46.0` — WebSocket improvements (`ws_max_size`, `ws_ping_interval`/`ws_ping_timeout` for `wsproto`), `--reset-contextvars` flag for ASGI request context isolation, proxy-headers fix preserving forwarded client ports.
- `asyncpg` `>=0.29` → `>=0.31.0` — Python 3.14 support (experimental subinterpreter/freethreading), connection-leak fix in `_can_use_connection`, multi-port connection-string fix.
- `python-multipart` `>=0.0.26` → `>=0.0.27` — header-limits and parse-offset constructor options.

All `>=` lower-bound bumps. No breaking changes for current users on Python 3.10+.

## Closes
- Closes #10
- Closes #11
- Closes #13

(#12 — aerich `>=0.8` → `>=0.9.2` — intentionally not batched here. Aerich has the `tortoise<1.0` pin entanglement; needs its own review pass.)

## Test plan
- [x] CI lint / typecheck / tests (3.10/3.12/3.14) / audit / docstrings / scan / sbom — all green from individual PRs
- [x] No application-level changes; behavior change limited to upstream library improvements above