### PR TITLE
bump: v1.15.2 — file ownership signaling (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Nori are documented here. Format follows [Keep a Changelo
 
 ---
 
+## [1.15.2] — 2026-04-27
+
+### Added
+
+- **`framework:update` pre-flight message** (`core/cli.py`). Before downloading the release zip, the command now prints the list of paths it is about to replace, derived live from `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES` (so the output stays in sync if those constants change). When backups are enabled, the backup destination is printed alongside, formatted as `rootsystem/.framework_backups/v<current>_<timestamp>/`. With `--no-backup`, the path-list still appears but the backup notice is suppressed. Closes the most common upgrade footgun: editing framework code, then losing those edits silently. Now you see the replacement list before the download starts and can Ctrl-C if needed.
+
+- **"File Ownership" section in `docs/architecture.md`**. Authoritative table mapping every path in a Nori project to its owner (Framework / You) and whether `framework:update` replaces it. Three rules of thumb — `core/`, `models/framework/`, and `requirements.nori.txt` are framework-owned; everything else under `rootsystem/application/` is yours. The page also explains the recovery path (the `rootsystem/.framework_backups/` directory) and the right extension points (controllers, service drivers, the config provider) for the cases where users would otherwise reach for `core/`.
+
+- **One-line ownership pointer comment in `core/__init__.py`** linking to the new docs section. Greppable, one place, no banner-spam in individual `core/*.py` files.
+
+### Test coverage
+
+- 1 new `framework_update` test (`test_framework_update_preflight_lists_replaced_paths_and_backup_location`) asserting the pre-flight lists every entry in `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES` (not a literal copy — the assertion iterates the constants), plus the backup-path hint with the current version embedded. The existing `test_framework_update_skip_backup_does_not_create_backup_dir` was extended to assert the pre-flight still appears but the backup-location notice is suppressed.
+
+### Compatibility
+
+- Pure additions. No public API changes, no settings keys added or renamed, no runtime dependency changes. The pre-flight message adds ~6 lines to `framework:update` output but does not change any side effects (no pause, no prompt, no extra IO). The new `core/__init__.py` comment is two lines of `#` and has no runtime effect.
+
+### Related
+
+- Resolves [#18](https://github.com/sembeimx/nori/issues/18). Companion to [#17](https://github.com/sembeimx/nori/issues/17) (open: `framework:check-config` for `pyproject.toml` drift detection).
+
+---
+
 ## [1.15.1] — 2026-04-27
 
 ### Test coverage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,46 @@ Everything else — authentication, validation, CSRF, JWT, collections, job queu
 
 ---
 
+## File Ownership
+
+A Nori project is a mix of **framework-owned** files (replaced wholesale on `framework:update`) and **site-owned** files (preserved across updates). Knowing the boundary up front prevents the most common upgrade footgun: editing framework code, then losing those edits on the next update.
+
+| Path | Owner | Replaced on `framework:update` |
+|------|-------|--------------------------------|
+| `rootsystem/application/core/**` | Framework | **Yes** — wholesale |
+| `rootsystem/application/models/framework/**` | Framework | **Yes** — wholesale |
+| `requirements.nori.txt` | Framework | **Yes** |
+| `rootsystem/application/asgi.py` | You | No (idempotent patches injected by `core._patches`) |
+| `rootsystem/application/settings.py` | You | No |
+| `rootsystem/application/routes.py` | You | No |
+| `rootsystem/application/modules/**` (controllers) | You | No |
+| `rootsystem/application/models/*.py` (your models — NOT in `framework/`) | You | No |
+| `rootsystem/application/seeders/**` | You | No |
+| `rootsystem/application/services/**` (mail, storage, search drivers) | You | No |
+| `rootsystem/application/commands/**` (your custom CLI commands) | You | No |
+| `requirements.txt`, `requirements-dev.txt` | You | No (`-r requirements.nori.txt` injected once by `core._patches`) |
+| `pyproject.toml`, `pytest.ini`, `Dockerfile`, `gunicorn.conf.py` | You (with framework seed at install time) | No |
+
+**Rule of thumb**: if a file lives under `core/` or `models/framework/`, or is named `requirements.nori.txt`, treat it as read-only. Everything else under `rootsystem/application/` is yours.
+
+### What happens if you edit a framework file anyway
+
+`framework:update` always backs up the framework directories before replacing them, in `rootsystem/.framework_backups/v<previous>_<timestamp>/`. So a lost edit is recoverable — but you have to know to look in the backup directory. The pre-flight message in `framework:update` lists the paths it is about to replace, so you can Ctrl-C if needed.
+
+If you find yourself wanting to patch framework behavior, the right pattern is almost always:
+
+- **Override at the controller layer** — add or replace a controller method in `modules/`.
+- **Add a service driver** — `services/storage_*.py`, `services/mail_*.py`, `services/search_*.py` are the integration points for swapping backends.
+- **Use the registered config provider** — `core.conf.config.MY_SETTING` reads from `settings.py`, so adding a setting + reading it from your code is preferred over editing `core/`.
+
+If none of those work, open an issue — that's a signal Nori is missing an extension point.
+
+### Authoritative source
+
+The lists above are derived from `_FRAMEWORK_DIRS` and `_FRAMEWORK_FILES` in `core/cli.py` and the `paths` array in `.starter-manifest.json`. If those change, this table changes — they are the source of truth. The `framework:update` pre-flight prints the live values from `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES`, so the runtime output stays in sync even if this page drifts.
+
+---
+
 ## Request Lifecycle
 
 Every HTTP request flows through this pipeline:

--- a/rootsystem/application/core/__init__.py
+++ b/rootsystem/application/core/__init__.py
@@ -1,3 +1,6 @@
+# This directory is framework-owned. `framework:update` replaces it wholesale.
+# See https://nori.sembei.mx/architecture/#file-ownership
+
 import warnings as _warnings
 
 # Suppress Tortoise's `Module "X" has no models` RuntimeWarning. In Nori the

--- a/rootsystem/application/core/cli.py
+++ b/rootsystem/application/core/cli.py
@@ -546,6 +546,15 @@ def framework_update(target_version: str | None = None, skip_backup: bool = Fals
         print('\n  Already up to date. Use --force to re-install.')
         return
 
+    print('\n  Will replace:')
+    for zip_path in _FRAMEWORK_DIRS:
+        print(f'    {zip_path}')
+    for file_name in _FRAMEWORK_FILES:
+        print(f'    {file_name}')
+    if not skip_backup:
+        print('\n  Your local edits in those paths will be backed up to')
+        print(f'  {_BACKUP_DIR}/v{current}_<timestamp>/')
+
     zip_url = f'https://github.com/{_GITHUB_REPO}/archive/refs/tags/{tag}.zip'
     print(f'\n  Downloading {tag}...')
 

--- a/rootsystem/application/core/version.py
+++ b/rootsystem/application/core/version.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = '1.15.1'
+__version__ = '1.15.2'

--- a/tests/test_core/test_cli.py
+++ b/tests/test_core/test_cli.py
@@ -1110,8 +1110,39 @@ def test_framework_update_skip_backup_does_not_create_backup_dir(update_env, mon
 
     out = capsys.readouterr().out
     assert 'Backing up' not in out
+    # Pre-flight should still appear, but the backup-location notice should not.
+    assert 'Will replace' in out
+    assert 'backed up to' not in out
     backups_root = update_env['tmp_path'] / 'rootsystem' / '.framework_backups'
     assert not backups_root.exists()
+
+
+def test_framework_update_preflight_lists_replaced_paths_and_backup_location(update_env, monkeypatch, capsys):
+    """Before downloading, the user sees what will be replaced and where the backup lands."""
+
+    def fake_download(url, dest):
+        _make_release_zip(
+            dest,
+            root='nori-1.99.0',
+            dirs=_release_dirs(),
+            files={'requirements.nori.txt': '# new\n'},
+        )
+
+    monkeypatch.setattr(cli, '_github_api', lambda endpoint: {'tag_name': 'v1.99.0'})
+    monkeypatch.setattr(cli, '_download_zip', fake_download)
+
+    cli.framework_update(target_version='1.99.0')
+
+    out = capsys.readouterr().out
+    assert 'Will replace:' in out
+    # Derived from _FRAMEWORK_DIRS / _FRAMEWORK_FILES — the assertion is about
+    # the data, not literal copy, so renaming the constants stays caught.
+    for zip_path in cli._FRAMEWORK_DIRS:
+        assert zip_path in out
+    for file_name in cli._FRAMEWORK_FILES:
+        assert file_name in out
+    assert 'backed up to' in out
+    assert f'v{"1.0.0"}_' in out  # current version embedded in the backup-path hint
 
 
 def test_framework_update_non_dict_release_aborts(update_env, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Three small, additive changes that make the **framework-owned vs site-owned** file boundary explicit at the moments it matters. Resolves #18.

1. **`framework:update` pre-flight** prints "Will replace: …" with the live contents of `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES` before downloading. With backups enabled, the backup destination prints alongside (`rootsystem/.framework_backups/v<current>_<timestamp>/`). With `--no-backup`, the path list still appears but the backup notice is suppressed.

2. **`docs/architecture.md` "File Ownership" section**: authoritative table mapping every path in a Nori project to Framework / You owner and whether `framework:update` replaces it. Plus the recovery path and the right extension points (controllers, service drivers, config provider) for the cases users would otherwise reach for `core/`.

3. **One-line ownership pointer comment** in `core/__init__.py` linking to the docs section. Greppable, one place, no banner-spam in `core/*.py`.

## Companion issue

- #17 (`framework:check-config` for `pyproject.toml` drift detection) — separate, not in this PR.

## Test plan
- [x] 1 new `framework_update` test asserting the pre-flight lists every entry in `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES` (iterates the constants — renaming them stays caught) plus the backup-path hint with `v<current>_` embedded
- [x] Existing `skip_backup` test extended to assert pre-flight still appears but backup notice is suppressed
- [x] Local: ruff lint + format + mypy clean (66 source files); 745 tests pass
- [ ] CI: lint / typecheck / tests (3.10/3.12/3.14) / audit / docstrings / scan / sbom