### PR TITLE
bump: v1.15.3 — framework:check-config (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to Nori are documented here. Format follows [Keep a Changelo
 
 ---
 
+## [1.15.3] — 2026-04-28
+
+### Added
+
+- **`framework:check-config` CLI command** — read-only diff of the project's `pyproject.toml` against the upstream Nori release's. `framework:update` refreshes framework code but never touches `pyproject.toml` (it would clobber user customizations), so projects silently fall behind on framework-side tooling improvements (new ruff rules, new `[[tool.mypy.overrides]]` strict modules, bumped coverage thresholds). The new command surfaces that drift without modifying anything.
+
+  The output is categorized into three sections:
+    - **Added upstream**: keys/tables present in the release but missing locally — usually additions worth adopting.
+    - **Changed upstream**: keys present in both with different values; each entry shows yours vs upstream (e.g. `tool.coverage.report.fail_under` `82` → `86`).
+    - **Local-only**: keys present locally but not upstream — your customizations, informational.
+
+  ```bash
+  python3 nori.py framework:check-config              # latest
+  python3 nori.py framework:check-config --version 1.15.2
+  ```
+
+  Implementation lives in `core/cli.py`: `_fetch_text()` retrieves the upstream `pyproject.toml` directly from `raw.githubusercontent.com/<repo>/<tag>/pyproject.toml` (lighter than the full release zip used by `framework:update`); `_diff_toml()` walks two parsed `tomlkit` documents in lockstep, returning categorized diffs keyed by dot-joined paths (e.g. `tool.coverage.report.fail_under`). Lists compare with `==` — any difference is reported as "changed" without element-wise diff (good enough for v1).
+
+  Resolves [#17](https://github.com/sembeimx/nori/issues/17).
+
+### Documentation
+
+- **`docs/cli.md`**: new `### framework:check-config` section with output anatomy and example invocations. Added to the command table.
+- **`docs/code_quality.md`**: new "Detecting drift against the latest release" subsection under "Customizing for your project", linking to the CLI reference.
+
+### Test coverage
+
+- 16 new tests in `tests/test_core/test_cli.py`:
+    - 6 unit tests for `_diff_toml` covering: matching docs, added upstream, changed value, local-only, nested table walking, list-difference treated as changed
+    - 8 end-to-end tests for `framework_check_config` covering: no-drift message, all three categories appear in output with the expected paths, 404 with `--version`, `URLError` on the API call, `URLError` on the raw fetch, missing local `pyproject.toml`, endpoint format `releases/tags/v{X}` with `--version`, endpoint `releases/latest` without
+    - 2 dispatcher tests asserting `main()` wires `framework:check-config` correctly with and without `--version`
+
+### Compatibility
+
+- Pure addition. New CLI subcommand; no existing commands or output formats changed. No new runtime dependencies (`tomlkit>=0.13` already in `requirements.nori.txt` since the aerich integration). Read-only — never modifies `pyproject.toml`.
+
+---
+
 ## [1.15.2] — 2026-04-27
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ python3 nori.py <command> [arguments]
 | `db:seed` | Run all registered database seeders |
 | `queue:work` | Run the persistent job queue worker |
 | `framework:update` | Update the Nori core from GitHub |
+| `framework:check-config` | Compare project's `pyproject.toml` against the current Nori release (read-only) |
 | `framework:version` | Show the current framework version |
 | `routes:list` | List all registered routes |
 | `audit:purge` | Purge old audit log entries |
@@ -279,6 +280,30 @@ python3 nori.py framework:update --no-backup
 7. Reminds you to regenerate framework migrations with `migrate:make ... --app framework` if framework models changed.
 
 For private repositories, set `GITHUB_TOKEN` in your environment.
+
+### `framework:check-config`
+
+Compares your project's `pyproject.toml` against the current Nori release's. **Read-only** — does not modify anything. The comparison answers: "what changed in the framework's tooling config since I installed, and what did I customize on top?"
+
+`framework:update` refreshes the framework's *code* but does not refresh `pyproject.toml` (it would clobber your customizations). Over many releases the framework may have introduced new ruff rules, new mypy strict modules, or bumped the coverage threshold — and your project never sees those changes silently. `framework:check-config` surfaces the drift.
+
+```bash
+python3 nori.py framework:check-config
+python3 nori.py framework:check-config --version 1.15.2
+```
+
+**Options**:
+- `--version <v>`: Compare against a specific Nori version. Defaults to the latest release.
+
+**Output** is categorized into three sections:
+
+- **Added upstream** — keys/tables present in the release's `pyproject.toml` but missing from yours. These are likely additions worth porting (e.g. a new `[[tool.mypy.overrides]]` block adding strict typing to a new module).
+- **Changed upstream** — keys present in both with different values. Each entry shows your value and upstream's. Example: `tool.coverage.report.fail_under` bumped from `82` to `86`.
+- **Local-only** — keys present in your `pyproject.toml` but not upstream. These are your customizations — informational, not a flag. The command prints them so you can review the full diff in one pass.
+
+If everything matches, the command prints `No drift detected.` and exits.
+
+The command does **not** modify `pyproject.toml`. You decide what to port. The output ends with a link to the upstream source for direct comparison.
 
 ### `framework:version`
 

--- a/docs/code_quality.md
+++ b/docs/code_quality.md
@@ -117,6 +117,17 @@ import bad_practice  # noqa: F401 — re-exported for backward compatibility, se
 
 The `pyproject.toml` is yours after install — `framework:update` does not replace it. Tighten or relax the configuration as your project matures.
 
+### Detecting drift against the latest release
+
+Because `pyproject.toml` is user-owned, projects can fall behind on framework-side tooling improvements (new ruff rules, new mypy strict modules, bumped coverage thresholds). To see what changed upstream without modifying anything locally:
+
+```bash
+python3 nori.py framework:check-config
+python3 nori.py framework:check-config --version 1.15.2
+```
+
+The output is a categorized diff (added upstream / changed / local-only) with full paths like `tool.coverage.report.fail_under`. Read-only — you decide what to port. See the [CLI reference](cli.md#framework-check-config) for the full command shape.
+
 ### Adding stricter rules
 
 ```toml

--- a/rootsystem/application/core/cli.py
+++ b/rootsystem/application/core/cli.py
@@ -496,6 +496,47 @@ def _download_zip(url: str, dest: str) -> None:
         shutil.copyfileobj(resp, f)
 
 
+def _fetch_text(url: str) -> str:
+    """Fetch a single text file (e.g. raw.githubusercontent.com/.../pyproject.toml)."""
+    req = Request(url, headers={'User-Agent': 'Nori-Framework-Updater'})
+    token = os.environ.get('GITHUB_TOKEN', '')
+    if token:
+        req.add_header('Authorization', f'Bearer {token}')
+    with urlopen(req) as resp:
+        return resp.read().decode('utf-8')
+
+
+def _diff_toml(local: dict, upstream: dict) -> tuple[dict, dict, dict]:
+    """Walk two parsed TOML documents in lockstep, returning categorized differences.
+
+    Returns (added_upstream, changed_upstream, local_only) where keys are dot-joined
+    paths (e.g. ``tool.coverage.report.fail_under``). Nested tables are walked
+    recursively; lists and scalars compare with ``==``.
+    """
+    added: dict = {}
+    changed: dict = {}
+    local_only: dict = {}
+
+    def walk(local_node: dict, upstream_node: dict, path: tuple[str, ...] = ()) -> None:
+        local_keys = set(local_node.keys())
+        upstream_keys = set(upstream_node.keys())
+
+        for key in sorted(upstream_keys - local_keys):
+            added['.'.join(path + (key,))] = upstream_node[key]
+        for key in sorted(local_keys - upstream_keys):
+            local_only['.'.join(path + (key,))] = local_node[key]
+        for key in sorted(local_keys & upstream_keys):
+            local_v = local_node[key]
+            upstream_v = upstream_node[key]
+            if isinstance(local_v, dict) and isinstance(upstream_v, dict):
+                walk(local_v, upstream_v, path + (key,))
+            elif local_v != upstream_v:
+                changed['.'.join(path + (key,))] = (local_v, upstream_v)
+
+    walk(local, upstream)
+    return added, changed, local_only
+
+
 def _has_existing_migrations() -> bool:
     """True if the project has user-generated migrations under ``migrations/<app>/``."""
     migrations_root = os.path.join(_APP_DIR, 'migrations')
@@ -660,6 +701,94 @@ def framework_update(target_version: str | None = None, skip_backup: bool = Fals
         print('\n  If upgrading from a Nori version with aerich <0.9.2, fill MODELS_STATE in')
         print('  existing migration files (one-time, idempotent):')
         print('    python3 nori.py migrate:fix')
+
+
+def framework_check_config(target_version: str | None = None) -> None:
+    """Diff the project's pyproject.toml against the upstream Nori release.
+
+    Read-only. Categorizes differences into:
+      - Added upstream: keys/tables present in the release but missing locally
+        (likely additions the user should consider adopting — new mypy strict
+        modules, bumped coverage thresholds, etc.)
+      - Changed upstream: keys present in both with different values
+      - Local-only: keys present locally but not upstream (likely user
+        customizations — informational, not a flag)
+    """
+    current = _get_current_version()
+    print('Nori framework:check-config')
+    print(f'  Current version: {current}')
+
+    try:
+        if target_version:
+            release = _github_api(f'releases/tags/v{target_version}')
+        else:
+            release = _github_api('releases/latest')
+    except HTTPError as e:
+        if e.code == 404:
+            print(
+                f'\n  Error: {"Version v" + target_version + " not found" if target_version else "No releases found"}.'
+            )
+            print(f'  Check https://github.com/{_GITHUB_REPO}/releases')
+            return
+        raise
+    except URLError as e:
+        print(f'\n  Error: Could not connect to GitHub — {e.reason}')
+        return
+
+    if not isinstance(release, dict):
+        print('\n  Error: Unexpected GitHub API response shape (not an object).')
+        return
+
+    tag = release['tag_name']
+    target = tag.lstrip('v')
+    print(f'  Comparing against: {target} ({tag})')
+
+    raw_url = f'https://raw.githubusercontent.com/{_GITHUB_REPO}/{tag}/pyproject.toml'
+    try:
+        upstream_text = _fetch_text(raw_url)
+    except (URLError, HTTPError) as e:
+        print(f'\n  Error: Could not fetch upstream pyproject.toml — {e}')
+        return
+
+    local_path = 'pyproject.toml'
+    if not os.path.exists(local_path):
+        print(f'\n  Error: No pyproject.toml at {local_path}')
+        return
+    with open(local_path) as f:
+        local_text = f.read()
+
+    import tomlkit
+
+    upstream_doc = tomlkit.parse(upstream_text)
+    local_doc = tomlkit.parse(local_text)
+
+    added, changed, local_only = _diff_toml(local_doc, upstream_doc)
+
+    if not added and not changed and not local_only:
+        print(f'\n  No drift detected. Your pyproject.toml matches Nori {target}.')
+        return
+
+    if added:
+        print('\n  Added upstream (not in your pyproject.toml):')
+        for path, value in added.items():
+            print(f'    + {path}')
+            if not isinstance(value, (dict, list)):
+                print(f'        = {value!r}')
+
+    if changed:
+        print('\n  Changed upstream:')
+        for path, (local_v, upstream_v) in changed.items():
+            print(f'    ~ {path}')
+            print(f'        you:      {local_v!r}')
+            print(f'        upstream: {upstream_v!r}')
+
+    if local_only:
+        print('\n  Local-only (your customizations — informational):')
+        for path in local_only:
+            print(f'    - {path}')
+
+    print('\n  This is read-only. Review the diff and port what makes sense.')
+    print(f'  Upstream source: {raw_url}')
 
 
 # ---------------------------------------------------------------------------
@@ -959,6 +1088,14 @@ def main() -> None:
     parser_update.add_argument('--no-backup', action='store_true', help='Skip backing up the current core/')
     parser_update.add_argument('--force', action='store_true', help='Re-install even if already on the target version')
 
+    parser_check_config = subparsers.add_parser(
+        'framework:check-config',
+        help="Compare project's pyproject.toml against the current Nori release (read-only)",
+    )
+    parser_check_config.add_argument(
+        '--version', default=None, help='Compare against a specific Nori version (default: latest)'
+    )
+
     subparsers.add_parser('framework:version', help='Show the current framework version')
     subparsers.add_parser('routes:list', help='List all registered routes')
     subparsers.add_parser('check:deps', help='Probe DB, cache, and throttle reachability (pre-deploy check)')
@@ -1003,6 +1140,8 @@ def main() -> None:
         queue_work(args.name)
     elif args.command == 'framework:update':
         framework_update(target_version=args.version, skip_backup=args.no_backup, force=args.force)
+    elif args.command == 'framework:check-config':
+        framework_check_config(target_version=args.version)
     elif args.command == 'framework:version':
         framework_version()
     elif args.command == 'routes:list':

--- a/rootsystem/application/core/version.py
+++ b/rootsystem/application/core/version.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = '1.15.2'
+__version__ = '1.15.3'

--- a/tests/test_core/test_cli.py
+++ b/tests/test_core/test_cli.py
@@ -829,6 +829,20 @@ def test_main_dispatches_framework_update_with_flags(monkeypatch):
     fn.assert_called_once_with(target_version='1.20.0', skip_backup=True, force=True)
 
 
+def test_main_dispatches_framework_check_config_with_version(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['nori.py', 'framework:check-config', '--version', '1.15.0'])
+    with patch('core.cli.framework_check_config') as fn:
+        cli.main()
+    fn.assert_called_once_with(target_version='1.15.0')
+
+
+def test_main_dispatches_framework_check_config_without_version(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['nori.py', 'framework:check-config'])
+    with patch('core.cli.framework_check_config') as fn:
+        cli.main()
+    fn.assert_called_once_with(target_version=None)
+
+
 def test_main_dispatches_framework_version(monkeypatch):
     monkeypatch.setattr('sys.argv', ['nori.py', 'framework:version'])
     with patch('core.cli.framework_version') as fn:
@@ -1188,3 +1202,207 @@ def test_framework_update_migrate_fix_reminder_shown_when_migrations_exist(updat
     out = capsys.readouterr().out
     assert 'migrate:fix' in out
     assert 'aerich <0.9.2' in out
+
+
+# ---------------------------------------------------------------------------
+# framework:check-config — read-only diff of pyproject.toml against a release
+# ---------------------------------------------------------------------------
+
+
+def test_diff_toml_returns_empty_when_documents_match():
+    import tomlkit
+
+    text = '[tool.ruff]\nline-length = 120\n[tool.coverage.report]\nfail_under = 86\n'
+    a = tomlkit.parse(text)
+    b = tomlkit.parse(text)
+
+    added, changed, local_only = cli._diff_toml(a, b)
+    assert added == {}
+    assert changed == {}
+    assert local_only == {}
+
+
+def test_diff_toml_detects_added_upstream():
+    import tomlkit
+
+    local = tomlkit.parse('[tool.coverage.report]\nfail_under = 82\n')
+    upstream = tomlkit.parse('[tool.coverage.report]\nfail_under = 82\nshow_missing = true\n')
+
+    added, changed, local_only = cli._diff_toml(local, upstream)
+    assert 'tool.coverage.report.show_missing' in added
+    assert added['tool.coverage.report.show_missing'] is True
+    assert changed == {}
+    assert local_only == {}
+
+
+def test_diff_toml_detects_changed_value():
+    import tomlkit
+
+    local = tomlkit.parse('[tool.coverage.report]\nfail_under = 82\n')
+    upstream = tomlkit.parse('[tool.coverage.report]\nfail_under = 86\n')
+
+    added, changed, local_only = cli._diff_toml(local, upstream)
+    assert 'tool.coverage.report.fail_under' in changed
+    local_v, upstream_v = changed['tool.coverage.report.fail_under']
+    assert local_v == 82
+    assert upstream_v == 86
+    assert added == {}
+    assert local_only == {}
+
+
+def test_diff_toml_detects_local_only_keys():
+    import tomlkit
+
+    local = tomlkit.parse('[tool.coverage.report]\nfail_under = 86\n[tool.my_plugin]\nfoo = "bar"\n')
+    upstream = tomlkit.parse('[tool.coverage.report]\nfail_under = 86\n')
+
+    added, changed, local_only = cli._diff_toml(local, upstream)
+    assert 'tool.my_plugin' in local_only
+    assert added == {}
+    assert changed == {}
+
+
+def test_diff_toml_walks_nested_tables():
+    """A change deep in a nested table is reported with the full dotted path."""
+    import tomlkit
+
+    local = tomlkit.parse('[tool.ruff.lint]\nselect = ["E", "W"]\n')
+    upstream = tomlkit.parse('[tool.ruff.lint]\nselect = ["E", "W", "F"]\n')
+
+    added, changed, local_only = cli._diff_toml(local, upstream)
+    assert 'tool.ruff.lint.select' in changed
+
+
+def test_diff_toml_treats_list_value_difference_as_changed():
+    """Lists compare with == — any difference (size or order) shows up as changed, not added."""
+    import tomlkit
+
+    local = tomlkit.parse('[a]\nitems = [1, 2]\n')
+    upstream = tomlkit.parse('[a]\nitems = [1, 2, 3]\n')
+
+    added, changed, local_only = cli._diff_toml(local, upstream)
+    assert 'a.items' in changed
+    assert added == {}
+
+
+@pytest.fixture
+def check_config_env(tmp_path, monkeypatch):
+    """Set up a tmp project with a baseline local pyproject.toml."""
+    (tmp_path / 'pyproject.toml').write_text('[tool.coverage.report]\nfail_under = 82\n')
+    core_dir = tmp_path / 'rootsystem' / 'application' / 'core'
+    core_dir.mkdir(parents=True)
+    (core_dir / 'version.py').write_text("__version__ = '1.15.0'\n")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_framework_check_config_no_drift_prints_no_drift_message(check_config_env, monkeypatch, capsys):
+    monkeypatch.setattr(cli, '_github_api', lambda endpoint: {'tag_name': 'v1.15.0'})
+    monkeypatch.setattr(cli, '_fetch_text', lambda url: '[tool.coverage.report]\nfail_under = 82\n')
+
+    cli.framework_check_config(target_version='1.15.0')
+
+    out = capsys.readouterr().out
+    assert 'No drift detected' in out
+
+
+def test_framework_check_config_reports_all_three_categories(check_config_env, monkeypatch, capsys):
+    """Local has fail_under=82 + tool.local_only; upstream has fail_under=86 + tool.added."""
+    upstream_text = '[tool.coverage.report]\nfail_under = 86\n[tool.added]\nnewkey = "x"\n'
+    (check_config_env / 'pyproject.toml').write_text(
+        '[tool.coverage.report]\nfail_under = 82\n[tool.local_only]\nmine = true\n'
+    )
+    monkeypatch.setattr(cli, '_github_api', lambda endpoint: {'tag_name': 'v1.15.1'})
+    monkeypatch.setattr(cli, '_fetch_text', lambda url: upstream_text)
+
+    cli.framework_check_config(target_version='1.15.1')
+
+    out = capsys.readouterr().out
+    assert 'Added upstream' in out
+    assert 'tool.added' in out
+    assert 'Changed upstream' in out
+    assert 'tool.coverage.report.fail_under' in out
+    assert 'Local-only' in out
+    assert 'tool.local_only' in out
+
+
+def test_framework_check_config_404_with_target_version(check_config_env, monkeypatch, capsys):
+    def fake_api(endpoint):
+        raise HTTPError('http://example', 404, 'Not Found', {}, io.BytesIO(b''))
+
+    monkeypatch.setattr(cli, '_github_api', fake_api)
+
+    cli.framework_check_config(target_version='9.9.9')
+
+    out = capsys.readouterr().out
+    assert 'Version v9.9.9 not found' in out
+
+
+def test_framework_check_config_url_error_on_api(check_config_env, monkeypatch, capsys):
+    def fake_api(endpoint):
+        raise URLError('No internet')
+
+    monkeypatch.setattr(cli, '_github_api', fake_api)
+
+    cli.framework_check_config()
+
+    out = capsys.readouterr().out
+    assert 'Could not connect to GitHub' in out
+
+
+def test_framework_check_config_url_error_on_fetch(check_config_env, monkeypatch, capsys):
+    monkeypatch.setattr(cli, '_github_api', lambda endpoint: {'tag_name': 'v1.15.0'})
+
+    def fake_fetch(url):
+        raise URLError('connection reset')
+
+    monkeypatch.setattr(cli, '_fetch_text', fake_fetch)
+
+    cli.framework_check_config(target_version='1.15.0')
+
+    out = capsys.readouterr().out
+    assert 'Could not fetch upstream pyproject.toml' in out
+
+
+def test_framework_check_config_missing_local_pyproject(tmp_path, monkeypatch, capsys):
+    core_dir = tmp_path / 'rootsystem' / 'application' / 'core'
+    core_dir.mkdir(parents=True)
+    (core_dir / 'version.py').write_text("__version__ = '1.0.0'\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, '_github_api', lambda endpoint: {'tag_name': 'v1.0.0'})
+    monkeypatch.setattr(cli, '_fetch_text', lambda url: '[a]\nb = 1\n')
+
+    cli.framework_check_config(target_version='1.0.0')
+
+    out = capsys.readouterr().out
+    assert 'No pyproject.toml' in out
+
+
+def test_framework_check_config_calls_releases_tags_when_target_version(check_config_env, monkeypatch):
+    captured: dict = {}
+
+    def fake_api(endpoint):
+        captured['endpoint'] = endpoint
+        return {'tag_name': 'v1.15.0'}
+
+    monkeypatch.setattr(cli, '_github_api', fake_api)
+    monkeypatch.setattr(cli, '_fetch_text', lambda url: '[tool.coverage.report]\nfail_under = 82\n')
+
+    cli.framework_check_config(target_version='1.15.0')
+
+    assert captured['endpoint'] == 'releases/tags/v1.15.0'
+
+
+def test_framework_check_config_calls_releases_latest_without_target_version(check_config_env, monkeypatch):
+    captured: dict = {}
+
+    def fake_api(endpoint):
+        captured['endpoint'] = endpoint
+        return {'tag_name': 'v1.15.0'}
+
+    monkeypatch.setattr(cli, '_github_api', fake_api)
+    monkeypatch.setattr(cli, '_fetch_text', lambda url: '[tool.coverage.report]\nfail_under = 82\n')
+
+    cli.framework_check_config()
+
+    assert captured['endpoint'] == 'releases/latest'


### PR DESCRIPTION
## Summary

New read-only CLI command — `python3 nori.py framework:check-config` — that diffs the project's `pyproject.toml` against the upstream Nori release's. `framework:update` refreshes framework code but never touches `pyproject.toml` (it would clobber user customizations), so projects silently fall behind on framework-side tooling improvements (new ruff rules, new mypy strict overrides, bumped coverage thresholds). The new command surfaces that drift without modifying anything.

Resolves #17.

## Output anatomy

```
$ python3 nori.py framework:check-config --version 1.15.2
Nori framework:check-config
  Current version: 1.10.0
  Comparing against: 1.15.2 (v1.15.2)

  Added upstream (not in your pyproject.toml):
    + tool.interrogate.fail-under
        = 70
    + tool.mypy.overrides

  Changed upstream:
    ~ tool.coverage.report.fail_under
        you:      75
        upstream: 86

  Local-only (your customizations — informational):
    - tool.my_company_plugin

  This is read-only. Review the diff and port what makes sense.
  Upstream source: https://raw.githubusercontent.com/sembeimx/nori/v1.15.2/pyproject.toml
```

If everything matches: `No drift detected. Your pyproject.toml matches Nori X.Y.Z.`

## Implementation notes

- `_fetch_text()` pulls just the upstream `pyproject.toml` from `raw.githubusercontent.com/<repo>/<tag>/pyproject.toml` — much lighter than the full release zip used by `framework:update`.
- `_diff_toml()` walks two parsed `tomlkit` documents in lockstep, returning three dicts (added / changed / local_only) keyed by dot-joined paths (e.g. `tool.coverage.report.fail_under`).
- Lists compare with `==` — any difference is reported as "changed" without element-wise diff. Good enough for v1; smarter list-of-tables diffing (e.g., per-`[[tool.mypy.overrides]]` entry) is a follow-up.
- No new runtime dependency: `tomlkit>=0.13` is already in `requirements.nori.txt` (used by aerich integration since the early days).
- Read-only — the function never opens `pyproject.toml` for writing.

## Test plan

- [x] **6 unit tests for `_diff_toml`**: matching documents, key added upstream, value changed, local-only key, nested table walking with full dotted path, list-difference treated as `changed`
- [x] **8 e2e tests for `framework_check_config`**: no-drift message, all 3 categories appear with expected paths, 404 with `--version`, `URLError` on API, `URLError` on raw fetch, missing local `pyproject.toml`, `releases/tags/v{X}` endpoint with `--version`, `releases/latest` without
- [x] **2 dispatcher tests** for `main()` wiring `framework:check-config` with and without `--version`
- [x] Local: ruff lint + format + mypy clean (66 source files); 761 tests pass (was 745)
- [ ] CI: lint / typecheck / tests (3.10/3.12/3.14) / audit / docstrings / scan / sbom

## Docs

- New `### framework:check-config` section in `docs/cli.md` with output anatomy and example invocations. Added to the command table.
- New "Detecting drift against the latest release" subsection in `docs/code_quality.md` under "Customizing for your project", linking back to the CLI reference.