### PR TITLE
ci: add Semgrep static analysis with 3 Nori custom rules

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,11 +19,19 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Pin floor so the deployed site does not drift to a future
+      # mkdocs-material that introduces theme changes or strict-mode
+      # rules we have not vetted. Bump deliberately when needed —
+      # the workflow is the only place we install this dependency.
       - name: Install MkDocs
-        run: pip install mkdocs-material
+        run: pip install 'mkdocs-material>=9.7.6'
 
+      # --strict promotes mkdocs warnings (unknown nav entries, missing
+      # files referenced by md_in_html, theme override issues) into hard
+      # failures. Dead-link / dead-anchor diagnostics stay at INFO and
+      # are caught by a separate sweep — see INVARIANTS.md INV-015.
       - name: Build docs
-        run: mkdocs build
+        run: mkdocs build --strict
 
       # FirebaseExtended/action-hosting-deploy still runs on Node 20 as of
       # 2026-04-21. Track https://github.com/FirebaseExtended/action-hosting-deploy/issues/448

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+# Fires when scripts/release.py pushes a v* tag (or when a maintainer
+# pushes one by hand). The job:
+#   1. checks the tag matches rootsystem/application/core/version.py
+#   2. extracts the matching CHANGELOG section as the release body
+#   3. creates the GitHub Release
+#
+# sbom.yml then fires on release: published and attaches the SBOM, so
+# every published release carries its own dependency manifest without
+# any extra manual step.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# We need `contents: write` to create the release; nothing else.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the tag commit is available for the version
+          # consistency check and so the CHANGELOG read sees the same
+          # file content the maintainer just pushed.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Verify tag matches version.py
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          TAG_VERSION="${TAG#v}"
+          FILE_VERSION=$(python3 -c "
+          import re, pathlib
+          src = pathlib.Path('rootsystem/application/core/version.py').read_text()
+          m = re.search(r'''__version__\s*=\s*['\"]([^'\"]+)['\"]''', src)
+          print(m.group(1) if m else '')
+          ")
+          if [ -z "$FILE_VERSION" ]; then
+            echo "::error::could not parse __version__ from rootsystem/application/core/version.py"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error::Tag $TAG (version $TAG_VERSION) does not match version.py ($FILE_VERSION)"
+            echo "::error::Use scripts/release.py to cut releases — it keeps the two in sync."
+            exit 1
+          fi
+          echo "version.py and tag agree on $TAG_VERSION"
+
+      - name: Extract CHANGELOG section for release body
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          python3 scripts/release.py --extract-changelog "$VERSION" > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "::error::extracted CHANGELOG body is empty for $VERSION"
+            exit 1
+          fi
+          echo "extracted $(wc -l < release_notes.md) lines of release notes"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release_notes.md \
+            --verify-tag

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,46 @@
+name: Semgrep
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Semgrep complements ruff (which already covers flake8-bandit via `S` codes) with:
+#   - Cross-line pattern analysis (TOCTOU read-modify-write, unguarded payload[],
+#     etc.) that ruff cannot express.
+#   - Curated public rulesets (Python general + security baseline + OWASP).
+#   - Nori-custom rules for bug classes ALREADY discovered in previous audits —
+#     see .semgrep/nori-rules.yml and .semgrep/README.md.
+#
+# Severity policy: --severity ERROR. WARNs are reported in stdout for visibility
+# but do not break the build. Custom rules graduate to ERROR after stabilising
+# without false positives.
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: pip
+
+      - run: pip install semgrep
+
+      - name: Semgrep — public rulesets + Nori custom rules
+        run: |
+          semgrep scan \
+            --config p/python \
+            --config p/security-audit \
+            --config p/owasp-top-ten \
+            --config .semgrep/ \
+            --severity ERROR \
+            --error \
+            --strict \
+            --metrics=off \
+            --disable-version-check

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ firebase-debug.log
 .claude/
 .gemini/
 CLAUDE.md
+.atl/

--- a/.semgrep/README.md
+++ b/.semgrep/README.md
@@ -1,0 +1,102 @@
+# Semgrep — Nori custom rules
+
+Versioned catalogue of Nori-specific invariants that are detectable statically.
+Each rule in `nori-rules.yml` corresponds to a **class of bug** already found
+in at least one previous audit.
+
+The goal is that no class mechanised here ever reappears as an audit finding:
+if it does, it is a regression, and CI should catch it on the PR — not on
+the next manual sweep.
+
+## Public rulesets enabled in CI
+
+Configured in `.github/workflows/semgrep.yml`:
+
+| Ruleset | Why | Severity gate |
+|---------|-----|---------------|
+| `p/python` | General language coverage (asyncio, pickle, deserialisation) | ERROR breaks CI |
+| `p/security-audit` | Common security baseline (eval, exec, shell subprocess) | ERROR breaks CI |
+| `p/owasp-top-ten` | OWASP categories — complements ruff bandit with cross-line analysis | ERROR breaks CI |
+
+`p/cwe-top-25` is omitted due to high overlap with `p/security-audit`. Re-evaluate
+at each audit whether any unique rules are worth including.
+
+## Adding a new rule
+
+1. Identify the **class** of bug (not the instance). A custom rule is only
+   justified if you expect the pattern to recur in the future.
+2. Look up the matching CWE at https://cwe.mitre.org/data/definitions/.
+   If none applies, the rule is probably framework-specific correctness —
+   that is fine, document why.
+3. Write the rule in `nori-rules.yml` following the template:
+
+   ```yaml
+   - id: nori-<kebab-case-descriptor>
+     message: |
+       <what was wrong>. <why it matters>. <how to fix>.
+       See CLAUDE.md §<section> + <relevant doc>.
+       [CWE-XXX] (if applicable)
+     severity: WARNING  # promote to ERROR once stabilised
+     languages: [python]
+     paths:
+       include: ["rootsystem/application/<scope>"]
+       exclude: ["tests/**"]
+     patterns:
+       - pattern: <Semgrep pattern>
+     metadata:
+       cwe: "CWE-XXX: <description>"
+       category: security|correctness
+   ```
+
+4. **Start at WARNING.** Promote to ERROR only after:
+   - Running `semgrep scan --config .semgrep/` against the full repo and
+     verifying 0 false positives (or silencing the known ones with `# nosem`
+     + justification).
+   - Surviving 1–2 PRs without causing unnecessary friction.
+
+5. If the rule includes paths with persistent legitimate false positives,
+   list them under `paths.exclude` with a comment explaining why they are
+   excluded (the same way `core/cache.py` is excluded from the TOCTOU rule —
+   it IS the implementation of the primitive).
+
+## Silencing an individual finding
+
+```python
+result = await cache_get(key)  # nosem: nori-toctou-cache-read-modify-write  -- intentional circuit breaker; DB is authoritative
+```
+
+The justification after `--` is mandatory. PRs without justification should be
+sent back in review. Same pattern as the `--ignore-vuln` documented in
+`.github/workflows/audit.yml`.
+
+## Running locally
+
+```bash
+pip install semgrep
+semgrep scan --config p/python --config p/security-audit --config .semgrep/
+```
+
+For custom rules only (fast, no remote pulls):
+
+```bash
+semgrep scan --config .semgrep/nori-rules.yml
+```
+
+To validate that a custom rule fires correctly (positive + negative cases):
+
+```bash
+semgrep scan --config .semgrep/nori-rules.yml --test
+```
+
+(Requires `*.test.py` files under `.semgrep/tests/` — TODO for iteration 2.)
+
+## Roadmap
+
+- **Iteration 1 (current)**: 3 custom rules (TOCTOU cache, JWT subscript, CLI
+  CWD path). Workflow breaks CI on ERROR. WARNs are reported without breaking.
+- **Iteration 2**: add rules for httpx connection reuse, async I/O hygiene in
+  services/*, queue allow-list bypass. Rule test suite under `.semgrep/tests/`.
+- **Iteration 3**: integrate into pre-commit (custom rules only — public
+  rulesets are too slow for a local hook).
+- **Iteration 4**: add CodeQL as a second layer for real data-flow analysis
+  (free on GitHub Actions for OSS).

--- a/.semgrep/README.md
+++ b/.semgrep/README.md
@@ -105,10 +105,23 @@ synthetic patterns as real findings.
   in services/ (ERROR) and synchronous open() inside async def in services/
   (WARNING). Test suite at `.semgrep/tests/nori-rules.py` with `# ruleid` /
   `# ok` annotations, validated via `semgrep --test`.
-- **Iteration 3**: integrate into pre-commit (custom rules only — public
-  rulesets are too slow for a local hook).
-- **Iteration 4**: add CodeQL as a second layer for real data-flow analysis
+- **Iteration 3 (shipped 2026-05-26)**: graduate INV-002 (sync I/O in async)
+  to L3 full. Added 3 rules: `nori-sync-time-sleep-in-async` (ERROR, core/ +
+  services/), `nori-sync-requests-import-in-services` (ERROR, services/),
+  `nori-sync-subprocess-in-async` (ERROR, core/ + services/ except cli.py
+  which is a sync entry script). INV-001 (TOCTOU) `services/*` swept
+  manually — zero usages, trivially covered. Total: 8 custom rules.
+- **Iteration 4 (next)**: integrate Semgrep custom rules into pre-commit
+  hook (custom rules only — public rulesets are too slow for local).
+- **Iteration 5**: add CodeQL as a second layer for real data-flow analysis
   (free on GitHub Actions for OSS).
-- **Iteration 5**: queue allow-list bypass detection. Hard to express statically
-  because the func_path argument to push() is often dynamic; would need a taint
-  rule or a manual review checklist instead.
+- **Iteration 6**: queue allow-list bypass detection. Hard to express
+  statically because `push()`'s func_path is often dynamic; would need a
+  taint rule or a manual review checklist instead.
+
+Next graduation candidates (see INVARIANTS.md roadmap table):
+
+- INV-007 to L3 full — add `cache_get` `_store` backend bypass detection
+- INV-027 to L3 full — extend CWD-path rule to `os.path.join` + broaden scope
+- INV-020 to L3 — detect `asyncio.create_task` without `add_done_callback`
+- INV-013 to L3 (rule) — generalize zip-slip detector

--- a/.semgrep/README.md
+++ b/.semgrep/README.md
@@ -85,18 +85,30 @@ semgrep scan --config .semgrep/nori-rules.yml
 To validate that a custom rule fires correctly (positive + negative cases):
 
 ```bash
-semgrep scan --config .semgrep/nori-rules.yml --test
+semgrep --test --config .semgrep/nori-rules.yml .semgrep/tests/nori-rules.py
 ```
 
-(Requires `*.test.py` files under `.semgrep/tests/` — TODO for iteration 2.)
+The annotations are inline:
+
+- `# ruleid: name` — the next line MUST trigger that rule
+- `# ok: name` — the next line MUST NOT trigger that rule
+- `# nosem: name -- justification` — silence a finding (also honoured by `--test`)
+
+The test file is listed in `.semgrepignore` so the main scan does not flag the
+synthetic patterns as real findings.
 
 ## Roadmap
 
-- **Iteration 1 (current)**: 3 custom rules (TOCTOU cache, JWT subscript, CLI
+- **Iteration 1 (shipped)**: 3 custom rules (TOCTOU cache, JWT subscript, CLI
   CWD path). Workflow breaks CI on ERROR. WARNs are reported without breaking.
-- **Iteration 2**: add rules for httpx connection reuse, async I/O hygiene in
-  services/*, queue allow-list bypass. Rule test suite under `.semgrep/tests/`.
+- **Iteration 2 (shipped)**: 2 more custom rules — httpx per-call AsyncClient
+  in services/ (ERROR) and synchronous open() inside async def in services/
+  (WARNING). Test suite at `.semgrep/tests/nori-rules.py` with `# ruleid` /
+  `# ok` annotations, validated via `semgrep --test`.
 - **Iteration 3**: integrate into pre-commit (custom rules only — public
   rulesets are too slow for a local hook).
 - **Iteration 4**: add CodeQL as a second layer for real data-flow analysis
   (free on GitHub Actions for OSS).
+- **Iteration 5**: queue allow-list bypass detection. Hard to express statically
+  because the func_path argument to push() is often dynamic; would need a taint
+  rule or a manual review checklist instead.

--- a/.semgrep/nori-rules.yml
+++ b/.semgrep/nori-rules.yml
@@ -191,7 +191,7 @@ rules:
           (see storage_gcs.py:_load_credentials for the canonical pattern)
       Once the helper is wrapped, silence this finding with:
         # nosem: nori-service-sync-open-in-async  -- nested in sync helper invoked via to_thread
-      See CLAUDE.md §6 — Async I/O hygiene.
+      See INVARIANTS.md INV-002.
     severity: WARNING
     languages: [python]
     paths:
@@ -202,5 +202,90 @@ rules:
           async def $F(...):
               ...
       - pattern: open(...)
+    metadata:
+      category: performance
+
+  # ---------------------------------------------------------------------------
+  # Iteration 3 — extend INV-002 sync-I/O detection beyond open()
+  # ---------------------------------------------------------------------------
+  # Three more sync calls that classically freeze the event loop when invoked
+  # inside an async def. Scoped to services/ + core/ but with explicit excludes
+  # for sites where the sync invocation is legitimate (cli.py is a sync entry
+  # script, not an async handler).
+  - id: nori-sync-time-sleep-in-async
+    message: |
+      time.sleep() inside an async def freezes the event loop — every other
+      coroutine pauses with it. Use `await asyncio.sleep(seconds)` for delays,
+      or wrap genuine blocking work in `asyncio.to_thread(...)` if you really
+      need sync semantics.
+      See INVARIANTS.md INV-002.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/services/"
+        - "**/rootsystem/application/core/"
+      exclude:
+        - "**/tests/**"
+    patterns:
+      - pattern-inside: |
+          async def $F(...):
+              ...
+      - pattern: time.sleep(...)
+    metadata:
+      category: performance
+      references:
+        - https://docs.python.org/3/library/asyncio-task.html#sleeping
+
+  - id: nori-sync-requests-import-in-services
+    message: |
+      `import requests` (or `from requests import ...`) in a service driver.
+      Nori service drivers MUST use httpx with a module-level AsyncClient
+      (INV-021). The `requests` library is sync-only — every call blocks the
+      event loop for the duration of the HTTP round-trip. Existing drivers
+      (mail_resend, storage_*, oauth_*, search_meilisearch) all use httpx;
+      see services/oauth_github.py for the canonical pattern.
+      See INVARIANTS.md INV-002 + INV-021.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/services/"
+    patterns:
+      - pattern-either:
+          - pattern: import requests
+          - pattern: from requests import $X
+    metadata:
+      category: performance
+
+  - id: nori-sync-subprocess-in-async
+    message: |
+      subprocess.run/check_output/check_call inside an async def blocks the
+      event loop until the child process exits. For sync entry scripts
+      (cli.py) this is fine and the rule excludes them. For async handlers,
+      use `asyncio.create_subprocess_exec(...)` / `create_subprocess_shell(...)`
+      or wrap the sync call in `asyncio.to_thread(subprocess.run, ...)`.
+      See INVARIANTS.md INV-002.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/services/"
+        - "**/rootsystem/application/core/"
+      exclude:
+        # cli.py is a sync CLI entry point — subprocess.run is the correct
+        # primitive for wrapping aerich/uvicorn/python -c scripts. The async
+        # invariant does not apply.
+        - "**/rootsystem/application/core/cli.py"
+        - "**/tests/**"
+    patterns:
+      - pattern-inside: |
+          async def $F(...):
+              ...
+      - pattern-either:
+          - pattern: subprocess.run(...)
+          - pattern: subprocess.check_output(...)
+          - pattern: subprocess.check_call(...)
+          - pattern: subprocess.Popen(...)
     metadata:
       category: performance

--- a/.semgrep/nori-rules.yml
+++ b/.semgrep/nori-rules.yml
@@ -137,3 +137,70 @@ rules:
           - pattern: Path("...")
     metadata:
       category: correctness
+
+  # ---------------------------------------------------------------------------
+  # Iteration 2 — httpx connection reuse in service drivers
+  # ---------------------------------------------------------------------------
+  # Each `httpx.AsyncClient()` constructor opens a fresh TCP+TLS handshake.
+  # Repeating the constructor per call stacks latency (TLS handshake adds
+  # ~100-200ms over WAN) and exhausts socket descriptors under load. Every
+  # existing services/* driver caches one `_client` at module level and
+  # registers a shutdown hook with `core.lifecycle` — see oauth_github.py
+  # for the canonical pattern. This rule guards forward against drivers
+  # that drop back to the `async with` constructor inside a hot path.
+  # See CLAUDE.md §6 — Connection reuse.
+  - id: nori-service-httpx-per-call-asyncclient
+    message: |
+      `async with httpx.AsyncClient(...)` constructed per call in a service
+      driver. Every constructor opens a fresh TCP+TLS connection — under
+      load this stacks latency and exhausts socket capacity. Hold a single
+      module-level _client and reuse it; register shutdown with
+      core.lifecycle.register_shutdown. See services/oauth_github.py for
+      the established pattern (_get_client + module-level _client cache).
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/services/"
+    patterns:
+      - pattern-either:
+          - pattern: |
+              async with httpx.AsyncClient(...) as $C:
+                  ...
+          - pattern: |
+              async with httpx.AsyncClient() as $C:
+                  ...
+    metadata:
+      category: performance
+
+  # ---------------------------------------------------------------------------
+  # Iteration 2 — synchronous open() inside async def in service drivers
+  # ---------------------------------------------------------------------------
+  # Disk I/O on the event loop freezes every other coroutine behind it. A
+  # slow disk or a network-mounted filesystem turns a single upload into
+  # a worker-wide stall. Wrap blocking calls in asyncio.to_thread or use
+  # aiofiles. The reads inside nested sync functions are fine — they will
+  # typically be invoked via asyncio.to_thread on the outside (see
+  # storage_gcs.py:_load_credentials for the pattern). See CLAUDE.md §6.
+  - id: nori-service-sync-open-in-async
+    message: |
+      open() called inside an async def in services/. Disk I/O on the
+      event loop freezes every other request behind it. Either:
+        - Wrap with asyncio.to_thread(lambda: open(...).read())
+        - Move into a nested sync helper invoked via asyncio.to_thread
+          (see storage_gcs.py:_load_credentials for the canonical pattern)
+      Once the helper is wrapped, silence this finding with:
+        # nosem: nori-service-sync-open-in-async  -- nested in sync helper invoked via to_thread
+      See CLAUDE.md §6 — Async I/O hygiene.
+    severity: WARNING
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/services/"
+    patterns:
+      - pattern-inside: |
+          async def $F(...):
+              ...
+      - pattern: open(...)
+    metadata:
+      category: performance

--- a/.semgrep/nori-rules.yml
+++ b/.semgrep/nori-rules.yml
@@ -1,0 +1,139 @@
+# Nori-specific Semgrep rules.
+#
+# Each rule detects a CLASS of bug already discovered in the framework.
+# When you find a new class in an audit, add it here with:
+#   - id in kebab-case prefixed with "nori-"
+#   - message that includes: what is wrong, why it matters, how to fix,
+#     where it is documented
+#   - severity ERROR (breaks CI) or WARNING (reports without breaking)
+#   - link to the CWE when applicable
+#
+# To silence a false positive: add `# nosem: <rule-id>  -- <justification>`
+# on the finding line. The justification is mandatory.
+#
+# Severity convention:
+#   ERROR   — breaks CI. Use when the detector is precise (few false positives).
+#   WARNING — reported in logs without breaking. Use for patterns with FP
+#             potential until the rule has been hardened against real usage.
+
+rules:
+
+  # ---------------------------------------------------------------------------
+  # CWE-367: Time-of-check Time-of-use (TOCTOU)
+  # ---------------------------------------------------------------------------
+  # Audit Round 4 (v1.18.0) found 3 instances of this pattern across
+  # login_guard.py, throttle_backends.py, and queue_worker.py — all of them
+  # silently broken security gates under concurrency.
+  #
+  # The established fix is cache_incr (counters) or cache_atomic_update
+  # (arbitrary read-modify-write). See docs/caching.md.
+  #
+  # Expected false positives (silence with # nosem):
+  #   - core/cache.py — this IS the implementation of the helpers.
+  #   - session_guard.py — cache is a read-through accelerator; DB is authoritative.
+  - id: nori-toctou-cache-read-modify-write
+    message: |
+      Possible TOCTOU: cache_get followed by cache_set in the same flow.
+      Under concurrency, two callers read the same baseline and clobber each
+      other on write. Use cache_incr (counters) or cache_atomic_update
+      (arbitrary read-modify-write). See CLAUDE.md §6 + docs/caching.md.
+      CWE-367.
+    severity: WARNING
+    languages: [python]
+    paths:
+      exclude:
+        - "**/rootsystem/application/core/cache.py"
+        - "**/tests/**"
+    patterns:
+      - pattern: |
+          $X = await cache_get($KEY, ...)
+          ...
+          await cache_set($KEY, ...)
+    metadata:
+      cwe: "CWE-367: Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')"
+      category: security
+      references:
+        - https://cwe.mitre.org/data/definitions/367.html
+
+  # ---------------------------------------------------------------------------
+  # JWT/OAuth payload subscript instead of .get()
+  # ---------------------------------------------------------------------------
+  # Third-party tokens do not always include the spec's "optional" claims
+  # (jti, sub, iss, aud). A KeyError in an auth handler bubbles up as a 500
+  # and a broken session = DoS path. See CLAUDE.md §6.
+  #
+  # Restricted to core/auth/* where "payload" is typically a JWT dict.
+  # Excludes assignments (we are creating the token, not reading it) and reads
+  # guarded by `if claim in payload`.
+  - id: nori-jwt-payload-required-claim
+    message: |
+      Payload accessed with []. If the claim is missing, KeyError → DoS path.
+      Use payload.get('claim') and handle the None explicitly.
+      See CLAUDE.md §6 — Optional spec fields.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/core/auth/"
+    patterns:
+      - pattern-either:
+          - pattern: $P['jti']
+          - pattern: $P['sub']
+          - pattern: $P['iss']
+          - pattern: $P['aud']
+          - pattern: $P['nbf']
+      # Exclude LHS of assignment (we are creating the token, not reading it).
+      # Each claim is listed explicitly — $K as a metavariable does not unify
+      # with specific string literals in Semgrep's matcher. pattern-not-inside
+      # (not pattern-not) is required because the positive pattern matches a
+      # subexpression nested inside the assignment statement.
+      - pattern-not-inside: $P['jti'] = $V
+      - pattern-not-inside: $P['sub'] = $V
+      - pattern-not-inside: $P['iss'] = $V
+      - pattern-not-inside: $P['aud'] = $V
+      - pattern-not-inside: $P['nbf'] = $V
+      # Exclude reads guarded by `if claim in payload` or `if claim not in payload`.
+      - pattern-not-inside: |
+          if $K in $P:
+              ...
+      - pattern-not-inside: |
+          if $K not in $P:
+              ...
+      - pattern-not-inside: |
+          if $K in $P and ...:
+              ...
+      - pattern-not-inside: |
+          if ... and $K in $P:
+              ...
+    metadata:
+      category: security
+      references:
+        - https://datatracker.ietf.org/doc/html/rfc7519#section-4.1
+
+  # ---------------------------------------------------------------------------
+  # CWD-relative Path() in core/cli.py
+  # ---------------------------------------------------------------------------
+  # nori.py does NOT chdir before invoking commands. Path('foo') resolves
+  # relative to the caller's CWD, so `python3 /srv/app/nori.py migrate:upgrade`
+  # from /tmp breaks with FileNotFoundError. Anchor to __file__.
+  # See CLAUDE.md §7 — Path resolution must be CWD-independent.
+  #
+  # Forward-looking guardrail: no matches today (cli.py uses os.path.join
+  # in _APP_DIR, an adjacent case — flagged in the manual audit report).
+  - id: nori-cli-cwd-relative-path
+    message: |
+      Path() with a string literal in core/cli.py is CWD-relative and breaks
+      when the command is invoked from a directory other than the project root.
+      Use: pathlib.Path(__file__).resolve().parent.parent / 'foo'
+      See CLAUDE.md §7.
+    severity: ERROR
+    languages: [python]
+    paths:
+      include:
+        - "**/rootsystem/application/core/cli.py"
+    patterns:
+      - pattern-either:
+          - pattern: pathlib.Path("...")
+          - pattern: Path("...")
+    metadata:
+      category: correctness

--- a/.semgrep/tests/nori-rules.py
+++ b/.semgrep/tests/nori-rules.py
@@ -149,3 +149,69 @@ async def safe_open_via_to_thread():
             return f.read()
 
     return await asyncio.to_thread(_load)
+
+
+# ===========================================================================
+# nori-sync-time-sleep-in-async
+# ===========================================================================
+
+import time
+
+
+async def bad_time_sleep():
+    # ruleid: nori-sync-time-sleep-in-async
+    time.sleep(1)
+
+
+async def safe_asyncio_sleep():
+    # ok: nori-sync-time-sleep-in-async
+    await asyncio.sleep(1)
+
+
+def sync_sleep_outside_async():
+    # ok: nori-sync-time-sleep-in-async
+    time.sleep(1)
+
+
+# ===========================================================================
+# nori-sync-requests-import-in-services
+# ===========================================================================
+
+# ruleid: nori-sync-requests-import-in-services
+import requests  # noqa: F401, E402  -- intentional positive case for Semgrep test
+
+
+def use_requests_at_module_scope():
+    # The import above already fires the rule; this just consumes the symbol.
+    return requests.get('https://example.com')
+
+
+# ok: nori-sync-requests-import-in-services
+import httpx  # noqa: F401, E402  -- httpx is the correct choice
+
+
+# ===========================================================================
+# nori-sync-subprocess-in-async
+# ===========================================================================
+
+import subprocess  # noqa: E402
+
+
+async def bad_subprocess_run_in_async():
+    # ruleid: nori-sync-subprocess-in-async
+    subprocess.run(['ls', '-la'], check=True)
+
+
+async def bad_subprocess_check_output_in_async():
+    # ruleid: nori-sync-subprocess-in-async
+    return subprocess.check_output(['echo', 'hi'])
+
+
+def sync_subprocess_outside_async():
+    # ok: nori-sync-subprocess-in-async
+    subprocess.run(['ls', '-la'], check=True)
+
+
+async def safe_subprocess_via_to_thread():
+    # ok: nori-sync-subprocess-in-async
+    return await asyncio.to_thread(subprocess.run, ['ls', '-la'], check=True)

--- a/.semgrep/tests/nori-rules.py
+++ b/.semgrep/tests/nori-rules.py
@@ -1,0 +1,151 @@
+"""Test fixtures for Nori custom Semgrep rules.
+
+This file is intentionally excluded from the main Semgrep scan (see
+.semgrepignore) so the rules do not flag these synthetic cases as real
+findings. It is used only via `semgrep --test --config .semgrep/`.
+
+Each block below uses Semgrep's inline test annotations:
+
+    "ruleid: NAME"  - the next line MUST trigger that rule (positive case)
+    "ok: NAME"      - the next line MUST NOT trigger that rule (negative case)
+
+Run with:
+
+    semgrep --test --config .semgrep/nori-rules.yml .semgrep/tests/nori-rules.py
+
+The harness compares the actual findings against these annotations and
+fails if any rule under- or over-fires. This is the cheapest possible
+regression test for the rules themselves.
+"""
+
+import asyncio
+import pathlib
+from pathlib import Path
+
+import httpx
+
+
+# ===========================================================================
+# nori-toctou-cache-read-modify-write
+# ===========================================================================
+
+async def toctou_bug():
+    # ruleid: nori-toctou-cache-read-modify-write
+    current = await cache_get('counter', 0)
+    await cache_set('counter', current + 1)
+
+
+async def safe_atomic():
+    # ok: nori-toctou-cache-read-modify-write
+    await cache_incr('counter')
+
+
+# ===========================================================================
+# nori-jwt-payload-required-claim
+# ===========================================================================
+
+def jwt_unguarded_read(payload):
+    # ruleid: nori-jwt-payload-required-claim
+    token_id = payload['jti']
+    return token_id
+
+
+def jwt_unguarded_subject(payload):
+    # ruleid: nori-jwt-payload-required-claim
+    sub = payload['sub']
+    return sub
+
+
+def jwt_assignment(payload):
+    # ok: nori-jwt-payload-required-claim
+    payload['jti'] = 'new-id'
+
+
+def jwt_guarded_read(payload):
+    if 'jti' in payload:
+        # ok: nori-jwt-payload-required-claim
+        return payload['jti']
+    return None
+
+
+def jwt_safe_get(payload):
+    # ok: nori-jwt-payload-required-claim
+    return payload.get('jti')
+
+
+# ===========================================================================
+# nori-cli-cwd-relative-path
+# ===========================================================================
+
+def bad_cli_path():
+    # ruleid: nori-cli-cwd-relative-path
+    p = pathlib.Path("rootsystem/application")
+    return p
+
+
+def bad_cli_path_short():
+    # ruleid: nori-cli-cwd-relative-path
+    p = Path("commands")
+    return p
+
+
+def safe_cli_path():
+    # ok: nori-cli-cwd-relative-path
+    p = pathlib.Path(__file__).resolve().parent
+    return p
+
+
+# ===========================================================================
+# nori-service-httpx-per-call-asyncclient
+# ===========================================================================
+
+async def bad_per_call_client():
+    # ruleid: nori-service-httpx-per-call-asyncclient
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        await client.get('https://example.com')
+
+
+async def bad_per_call_client_no_args():
+    # ruleid: nori-service-httpx-per-call-asyncclient
+    async with httpx.AsyncClient() as client:
+        await client.get('https://example.com')
+
+
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        # ok: nori-service-httpx-per-call-asyncclient
+        _client = httpx.AsyncClient(timeout=30.0)
+    return _client
+
+
+async def safe_reuses_singleton():
+    client = _get_client()
+    # ok: nori-service-httpx-per-call-asyncclient
+    await client.get('https://example.com')
+
+
+# ===========================================================================
+# nori-service-sync-open-in-async
+# ===========================================================================
+
+async def bad_sync_open_in_async():
+    # ruleid: nori-service-sync-open-in-async
+    with open('/etc/secrets.json') as f:
+        return f.read()
+
+
+async def safe_open_via_to_thread():
+    def _load():
+        # The nested sync helper IS the pattern — the surrounding async
+        # invokes via to_thread. Semgrep cannot distinguish nested sync
+        # def from the outer async def, so the rule fires here and we
+        # silence it with the documented marker.
+        # nosem: nori-service-sync-open-in-async  -- nested in sync helper invoked via to_thread
+        with open('/etc/secrets.json') as f:
+            return f.read()
+
+    return await asyncio.to_thread(_load)

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,12 @@
+# Synthetic positive/negative trigger cases for Nori custom rules.
+# Scanned only via `semgrep --test --config .semgrep/` (which honours the
+# inline `# ruleid:` / `# ok:` annotations); excluded from the main scan
+# so the rules do not flag the synthetic patterns as real findings.
+.semgrep/tests/
+
+# Virtual envs created by contributors locally — never scan.
+.venv/
+venv/
+
+# Tortoise migrations are aerich-generated SQL; not framework logic to audit.
+rootsystem/application/migrations/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,79 +77,49 @@ class User(NoriModelMixin, Model):
 ---
 
 ## 6. Security Mandates
+
+These are quick reference reminders. The full catalog of bug classes (with CWE links, fix recipes, detector maturity, and coverage by area) lives in [INVARIANTS.md](./INVARIANTS.md) — read that file before shipping any security-relevant change.
+
 - **POST only**: All state-changing actions (Logout, Delete, Update) MUST be `POST`.
 - **Audit Logging**: Use `audit(request, action, model_name, record_id)` for sensitive operations.
-- **Serialization**: Always use `.to_dict()` to leverage `protected_fields` safety.
-- **Cache atomicity**: Any read-modify-write against the cache backend (counters, rate-limit windows, login guards, lockouts, dedup keys) MUST use `cache_incr` or `cache_atomic_update`. Plain `cache_get + cache_set` for an update is a TOCTOU bug — under concurrency, parallel callers all see the same baseline and clobber each other. The v1.18.0 audit found three of these, every one bypassing a security control.
-- **Async I/O hygiene**: Service drivers (`services/*`) MUST offload synchronous disk I/O and heavy CPU (cryptographic signing, hashing, image decoding) via `asyncio.to_thread`. Running those operations directly on the async loop freezes every other request behind them — a single slow upload or RSA token refresh stalls the whole worker.
-- **Connection reuse**: Service drivers that use `httpx` MUST hold one persistent `httpx.AsyncClient` at module level, not per-call. Each `httpx.AsyncClient()` constructor opens a new TCP/TLS connection — repeating that on every request stacks latency and exhausts socket capacity under load.
-- **Optional spec fields**: JWT/OAuth claim access MUST treat optional fields as `None` by default (`payload.get('jti')`, not `payload['jti']`). Third-party tokens won't always include them, and a `KeyError` in a logout or callback handler is a denial-of-service path.
+- **Serialization**: Always use `.to_dict()` to leverage `protected_fields` safety. See [INV-008](./INVARIANTS.md#inv-008-serializers-must-respect-protected_fields).
+- **Cache atomicity**: Use `cache_incr` or `cache_atomic_update` — never `cache_get + cache_set` for read-modify-write. See [INV-001](./INVARIANTS.md#inv-001-cache-read-modify-write-must-be-atomic-toctou).
+- **Async I/O hygiene**: Wrap sync disk I/O and heavy CPU in `asyncio.to_thread`. See [INV-002](./INVARIANTS.md#inv-002-sync-work-must-not-block-the-asyncio-event-loop).
+- **Connection reuse**: One module-level `httpx.AsyncClient` per service driver. See [INV-021](./INVARIANTS.md#inv-021-httpx-clients-must-be-reused-per-service-driver).
+- **Optional spec fields**: `payload.get('jti')`, never `payload['jti']`. See [INV-007](./INVARIANTS.md#inv-007-jwtoauth-optional-claims-must-be-accessed-defensively).
+- **Queue payloads**: `func_path` must pass `QUEUE_ALLOWED_MODULES` allow-list. See [INV-003](./INVARIANTS.md#inv-003-queue-worker-func_path-must-pass-allow-list-check-rce-defense).
+- **Session revocation**: All session-aware decorators (`login_required`, `require_role`, `require_any_role`, `require_permission`) check `session_version` against the live counter. See [INV-016](./INVARIANTS.md#inv-016-session-revocation-must-work-end-to-end-active-user-gate--version-counter).
 
 ---
 
 ## 7. Operational Pitfalls (for framework changes)
 
-These are Nori-specific traps discovered the hard way. Read before changing the listed areas.
+Code-side bug classes (TOCTOU, sync I/O, CWD-relative paths, docs↔code coherence, etc.) are in [INVARIANTS.md](./INVARIANTS.md). This section covers infra and deploy traps that do not fit the catalog shape.
 
 ### Hosting and docs deploys
 - `nori.sembei.mx` runs on **Firebase Hosting**, not a VPS. Deploy is automatic via `.github/workflows/deploy-docs.yml` on every push to `main` that touches `docs/**` or `mkdocs.yml`. No manual `firebase deploy` is needed.
 - The version badge in the docs sidebar is **client-side JavaScript** — the GitHub repo widget queries the API at page load. When it looks stale after a release, the fix is browser cache (hard reload, or unregister the service worker). Re-running the deploy workflow will NOT update it.
 - Verify the actual host with `dig +short nori.sembei.mx` before assuming. Memory of past deploys can be stale.
+- MkDocs publishes any `.md` file inside `docs/` even if not listed in `nav:` — direct URL works. Internal-only docs (such as [INVARIANTS.md](./INVARIANTS.md)) MUST live outside `docs/` to stay private.
 
 ### Releases and the installer
 - `gh release create` → `releases/latest` API has a ~30-second indexing lag. The installer (`docs/install.py`) hits `releases/latest` by default, so the first install within ~1 minute of a release may pull the previous version. For testing right after release, pass `--version VX.Y.Z` to skip the latest endpoint.
 - Always verify a release end-to-end with the installer (real `curl ... | python3 -`) before considering it shipped.
+- Installer integrity contract: see [INV-025](./INVARIANTS.md#inv-025-installer-must-verify-checksum-of-downloaded-archive).
 
 ### CLI subprocess scripts (`core/cli.py`)
-- When a CLI command spawns a Python subprocess that imports user code (`routes`, `modules`, `models`), the script MUST start with:
-  ```python
-  import sys
-  sys.path.insert(0, '.')
-  import settings
-  from core.conf import configure
-  configure(settings)
-  ```
-  before importing anything that may touch `config.X`, `templates.env`, or any lazy framework state. Otherwise the command crashes with `RuntimeError: Nori config not initialised` on projects whose user code touches config at module-import time. See `migrate_init`, `migrate_upgrade`, `routes_list` for the established pattern.
+- See [INV-026](./INVARIANTS.md#inv-026-cli-subprocess-scripts-must-call-configuresettings-before-importing-user-code) for the `configure(settings)` bootstrap requirement.
+- See [INV-027](./INVARIANTS.md#inv-027-file-and-module-path-resolution-must-be-cwd-independent) for CWD-independent path resolution.
 - For aerich subprocesses, use `env=_quiet_env()` to suppress the `Module "X" has no models` RuntimeWarning. The same warning is filtered in-process via `core/__init__.py`.
 
-### Path resolution must be CWD-independent
-- `nori.py` adds `rootsystem/application` to `sys.path` but does NOT `chdir` into it. Code that resolves files/modules must NOT use `pathlib.Path('something')` (CWD-relative). Anchor to the module file:
-  ```python
-  pathlib.Path(__file__).resolve().parent.parent / 'something'
-  ```
-- When a function changes its path resolution or discovery contract, grep ALL test files for fixtures using `monkeypatch.chdir` or `monkeypatch.setattr` against the affected module BEFORE shipping. CI catches this but a 30-second grep avoids the red CI + follow-up commit.
+### Repo-state lints
+- See [INV-028](./INVARIANTS.md#inv-028-repo-state-itself-can-be-a-bug-ship-time-invariants).
 
-### Repo-state lints catch ship-time bugs that unit tests miss
-- Some bugs are not in code but in committed files (the v1.8.0 → v1.10.2 incident: leftover `.gitkeep` files that silently broke `migrate:init` for two releases). Unit tests of the affected function passed because the test environment didn't have the bad files. The right test layer is a static repo-state assertion. See `test_repo_does_not_ship_migrations_dir` for the pattern.
-- When fixing "the repo shouldn't ship X" bugs, add a regression test that asserts the file/dir doesn't exist in the source tree.
+### Configurable settings defaults
+- See [INV-029](./INVARIANTS.md#inv-029-new-settings-must-default-via-configgetkey-default).
 
-### Configurable URLs / settings have defaults via `config.get(key, default)`
-- New user-overridable settings (like `LOGIN_URL`, `FORBIDDEN_URL`, `PERMISSIONS_TTL`) use `config.get('SETTING', default_value)` rather than `config.SETTING`. This keeps existing projects working when they haven't set the new key, while letting projects override via `settings.py`. Always provide a default that matches the previous hardcoded behavior — backward compatibility is non-negotiable.
-
-### Concurrency hazards: TOCTOU in cache-backed counters
-
-- **The bug class**: a function does `await cache_get(key)` → modify in Python → `await cache_set(key, new_value)`. Under concurrency this fails — two callers both read the same baseline, both compute the same `+1`, both write the same `+1`. The counter never advances. Any security gate built on top (lockouts, rate limits, dedup checks) is silently disabled. Audit Round 4 surfaced this in three independent places: `core/auth/login_guard.py`, `core/http/throttle_backends.py`, and `core/queue_worker.py` (Redis delayed-job promotion, fixed earlier).
-- **The fix**: `cache_incr` for scalar counters; `cache_atomic_update(key, fn, ttl)` for any other read-modify-write. Both live in `core/cache.py` and are documented in `docs/caching.md`. Memory backend serializes via the global lock; Redis uses Lua (`incr`) or WATCH/MULTI/EXEC retry (`atomic_update`).
-- **The check**: before shipping code that touches `cache_get` or `cache_set`, look for the partner call in the same logical operation. `rg -n 'cache_get|cache_set' <file>` plus visual review — if both appear and one informs the other, the right answer is `cache_atomic_update`, not "wrap them in a lock".
-- **NOT for distributed locks**: these primitives replace read-modify-write loops, not advisory locks across services. If you need cross-service mutual exclusion ("only one worker runs the daily report"), that's a different problem.
-
-### Docs↔code coherence: the class of bug ruff/mypy cannot catch
-
-- **The bug class**: a comment, docstring, or docs page describes behavior X (order, lifecycle, ownership, ordering of effects), the code does Y, and both compile cleanly. ruff, mypy, and high coverage all pass — only manual review surfaces it. The v1.15.4 incident is the canonical example: `asgi.py` had `middleware.insert(1, CORSMiddleware)` while the file's own comment AND `docs/architecture.md` AND `docs/middleware.md` all documented the order that would require `insert(2, ...)`. CORS preflight responses silently shipped without security headers in every project that enabled CORS.
-- **High-leverage targets** — touching any of these requires reviewing docs and code together in the same change:
-  - `rootsystem/application/asgi.py` (middleware order, lifespan)
-  - `rootsystem/application/settings.py` (defaults that affect lifecycle/ownership)
-  - `rootsystem/application/core/cli.py` (CLI commands and flags described in `docs/cli.md`)
-  - `rootsystem/application/core/auth/csrf.py`, `core/http/validation.py` (rule precedence described in docs)
-  - `rootsystem/application/core/queue_worker.py`, `core/queue.py` (queue payload allow-list contract + Redis atomic promotion described in `docs/background_tasks.md` and `docs/security.md`)
-  - `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES` (file ownership described in `docs/architecture.md`)
-- **The checklist** before shipping a change to any file above:
-  1. Grep `docs/**/*.md` for code snippets that mirror the file you changed (`rg 'middleware.insert\(' docs/`, `rg '\<path-affected\>' docs/`).
-  2. Read the surrounding prose, not just the snippet — the snippet may be right but the description above it stale, or vice versa.
-  3. If a comment in the file describes order/lifecycle, verify the code below the comment still does that.
-  4. When in doubt, run an exploration agent with the explicit prompt "find docs-vs-code mismatches related to <area>". Cheap, fast, finds the same bug a custom CI check would — without the maintenance cost.
-- **Do NOT add a custom regex CI check after the first incident.** One data point doesn't justify a per-pattern linter that will go stale, fire false positives, and eventually be muted. Wait for repetition before automating; the manual review + agent-assisted audit handles single occurrences cheaper.
-- **The fix is bidirectional**: when you find a mismatch, the docs are not always wrong. v1.15.4's docs declared the correct intent — the code was the bug. Always determine which side is canonical before "fixing" the divergence.
+### Docs↔code coherence
+- See [INV-015](./INVARIANTS.md#inv-015-docs-and-code-must-stay-coherent-manual-review-on-high-leverage-files) for the high-leverage file list and the per-PR review checklist.
 
 ---
-*For deep-dives into specific modules (WebSockets, Mail, Search, etc.), refer to the [docs/](docs/) directory.*
+*For deep-dives into specific modules (WebSockets, Mail, Search, etc.), refer to the [docs/](docs/) directory. For the bug-class catalog, see [INVARIANTS.md](./INVARIANTS.md).*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Nori are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+When a release is cut, rename `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD` and seed a fresh empty `[Unreleased]` block above it. The release script (`scripts/release.sh`, when in place) does this transformation automatically and extracts the renamed section as the GitHub Release body.
+
+---
+
+## [Unreleased]
+
+_Nothing accumulated yet — add entries here as they ship to `main` so the next release cut is just a rename + date stamp._
+
 ---
 
 ## [1.34.0] — 2026-04-30

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ RUN apt-get update && apt-get install -y default-libmysqlclient-dev && rm -rf /v
 COPY --from=builder /install /usr/local
 COPY . .
 
+# Run as a non-privileged user — limits the blast radius of a container
+# escape and satisfies Semgrep dockerfile.security.missing-user (p/security-audit).
+# chown is needed because COPY runs as root; gunicorn workers spawn under `nori`.
+RUN useradd --create-home --uid 1000 nori && chown -R nori:nori /app
+USER nori
+
 EXPOSE 8000
 
 CMD ["gunicorn", "asgi:app", "-c", "gunicorn.conf.py", "--chdir", "rootsystem/application"]

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -100,14 +100,14 @@ Listed in order of historical discovery (oldest first). IDs are stable.
 - **Detector maturity**:
   - L1: yes
   - L2: `rg -n 'cache_get|cache_set' <file>` + visual review for partner calls
-  - L3: `.semgrep/nori-rules.yml::nori-toctou-cache-read-modify-write` (WARNING, since 2026-05)
+  - L3: `.semgrep/nori-rules.yml::nori-toctou-cache-read-modify-write` (WARNING, since 2026-05). Scans full repo except `core/cache.py` (implementation) and tests.
 - **Coverage by area**:
   - `core/auth/*`: swept Round 4 + L3 active
   - `core/http/throttle*`: swept Round 4 + L3 active
   - `core/queue*`: swept Round 4 + L3 active
   - `core/cache.py`: excluded from L3 (implementation site)
   - `core/auth/session_guard.py`: excluded from L3 (read-through accelerator pattern)
-  - `services/*`: **NOT explicitly swept** against this INV
+  - `services/*`: swept 2026-05-26 — zero `cache_get`/`cache_set` usages; trivially covered. L3 active going forward.
   - User code (`app/*`, `modules/*`): out of framework scope
 - **Instances**:
   - v1.18.0: `login_guard.record_failed_login` — `cache_get` + `cache_set` on attempts dict
@@ -131,15 +131,22 @@ Listed in order of historical discovery (oldest first). IDs are stable.
 - **Detector maturity**:
   - L1: yes
   - L2: `rg -n 'async def' --files-with-matches services/ | xargs rg -n 'open\(|time\.sleep|.*\.encrypt|.*\.sign'`
-  - L3: `.semgrep/nori-rules.yml::nori-service-sync-open-in-async` (WARNING, since 2026-05). Only covers `open()` in `services/*`; other sync calls (crypto, hashing, image decoding) are still L1/L2.
+  - L3 (multiple rules, since 2026-05):
+    - `nori-service-sync-open-in-async` (WARNING): `open()` in `services/*` async def
+    - `nori-sync-time-sleep-in-async` (ERROR): `time.sleep()` in `core/* + services/*` async def (excludes tests)
+    - `nori-sync-requests-import-in-services` (ERROR): `import requests` / `from requests import X` in `services/*` (httpx is the contract)
+    - `nori-sync-subprocess-in-async` (ERROR): `subprocess.run/check_output/check_call/Popen` in async def in `core/* + services/*` (excludes `core/cli.py` which is a sync entry script)
+  - Still L1/L2: sync crypto/hashing (`hashlib.pbkdf2_hmac`, `bcrypt.hashpw`), image decoding, `urllib.request.urlopen`. Difficult to mechanize without false positives because these calls are legitimate in non-async contexts; rely on per-PR review.
 - **Coverage by area**:
   - `services/storage_gcs.py`: swept Round 4 (RSA + cred load via to_thread)
-  - `services/*` (open() detection only): L3 since 2026-05
+  - `services/*` (open, time.sleep, requests import, subprocess in async): L3 since 2026-05-26
+  - `core/*` (time.sleep, subprocess in async): L3 since 2026-05-26
+  - `core/cli.py`: excluded from subprocess rule (sync entry script — subprocess.run is correct primitive)
   - `core/http/upload.py`: swept Round 3 (`asyncio.to_thread` for disk write)
   - `core/auth/security.py`: swept v1.22.0 (PBKDF2 async)
   - `core/tasks.py`: swept v1.27.0 (background dispatcher offloads sync)
   - `core/queue_worker.py`: swept v1.30.0 (execute_payload offloads sync)
-  - Other crypto callsites (JWT signing, etc.): **NOT explicitly swept**
+  - Other crypto callsites (JWT signing, etc.): **NOT explicitly swept** at L3
 - **Instances**:
   - v1.17.0: `core/http/upload.py` write_bytes on loop
   - v1.18.0: `services/storage_gcs.py` `_load_credentials` + `_build_jwt`
@@ -784,8 +791,8 @@ These are the highest-leverage Semgrep/test mechanizations remaining. Sorted by 
 
 | Priority | INV | Current | Target | Why |
 |----------|-----|---------|--------|-----|
-| HIGH | INV-002 | L3 partial (open() in services/ only) | L3 full | Extend rule to other sync calls (crypto, time.sleep, file walks) across `core/` and `services/` |
-| HIGH | INV-001 | L3 partial (services/* not swept) | L3 full | Sweep `services/*` for `cache_get`+`cache_set` partner patterns |
+| ~~HIGH~~ | ~~INV-002~~ | ~~L3 partial~~ | ✅ L3 full (open + time.sleep + requests + subprocess) | **Done 2026-05-26 — iter 3.** Crypto/hashing still L1/L2 (low FP value). |
+| ~~HIGH~~ | ~~INV-001~~ | ~~L3 partial (services/* not swept)~~ | ✅ L3 full | **Done 2026-05-26 — iter 3.** `services/*` swept manually; zero usages. Rule already scans the path. |
 | MED | INV-007 | L3 partial (subscript only, jti/sub/iss/aud/nbf) | L3 full | Add `cache_get` `_store` backend bypass detection |
 | MED | INV-027 | L3 partial (Path() in cli.py only) | L3 full | Extend to `os.path.join` and broaden to `core/`, `services/` |
 | MED | INV-020 | L1/L2 | L3 | Detect `asyncio.create_task` without `add_done_callback` |
@@ -806,3 +813,4 @@ When you complete an audit pass, append here:
 | Date | Scope | New INVs | Regressions of existing INVs | Notes |
 |------|-------|----------|------------------------------|-------|
 | 2026-05-25 | full sweep (code + docs + tests) | none (all 4 Criticals matched existing INVs: INV-004 docs side, INV-026 shell, INV-016 require_role/any_role test gap, INV-007 OAuth subscript propagation) | INV-015 (4 doc mismatches), INV-027 (cli.py:20 `_APP_DIR`) | Shipped Semgrep CI (PR #28) — 5 custom rules across INV-001, INV-002, INV-007, INV-021, INV-027 |
+| 2026-05-26 | iter 3 graduation: INV-002 + INV-001 to L3 full | none | none | Added 3 new Semgrep rules: `nori-sync-time-sleep-in-async`, `nori-sync-requests-import-in-services`, `nori-sync-subprocess-in-async`. `services/*` swept manually for INV-001 partner calls — zero usages. Full repo scan: 8 rules × 71 files = 0 findings. Convergence metric: 0 new classes, 0 regressions — pure mechanization work. |

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -455,8 +455,9 @@ Listed in order of historical discovery (oldest first). IDs are stable.
 - **Coverage by area**: covered by per-PR discipline + per-release sweep
 - **Instances**:
   - v1.15.4: CORS at `insert(1, ...)` while docs documented `insert(2, ...)`
-  - 2026-05 audit: 4 mismatches (CSRF JSON exemption, body cap 10MB vs 1MiB, SECRET_KEY validation claim, exempt_paths type)
-- **Regression tests**: `test_middleware_order_with_cors_keeps_security_headers_outside_cors` pins the specific v1.15.4 invariant; no general lint
+  - 2026-05-25 audit: 4 mismatches (CSRF JSON exemption, body cap 10MB vs 1MiB, SECRET_KEY validation claim, exempt_paths type)
+  - 2026-05-26 git/release flow review: 4 more — `mkdocs.yml` declared `provider: mike` with mike never installed anywhere; `docs/deployment.md` "Documentation site" section described a VPS+rsync+Apache+Certbot pipeline while the actual deploy is Firebase Hosting + GitHub Actions; `docs/code_quality.md:129` linked to `cli.md#framework-check-config` while the real slug is `#frameworkcheck-config`; `docs/dependencies.md:111` linked to `observability.md#upgrading-an-existing-site` which never existed.
+- **Regression tests**: `test_middleware_order_with_cors_keeps_security_headers_outside_cors` pins the specific v1.15.4 invariant. `mkdocs build --strict` in CI (since 2026-05-26) catches the WARNING-level subset (unknown nav entries, theme overrides). Dead anchors remain at INFO level — caught only by manual sweep until a separate link-checker is added.
 - **Related**: every other INV (the docs side of every INV should match the code)
 
 ---
@@ -814,3 +815,4 @@ When you complete an audit pass, append here:
 |------|-------|----------|------------------------------|-------|
 | 2026-05-25 | full sweep (code + docs + tests) | none (all 4 Criticals matched existing INVs: INV-004 docs side, INV-026 shell, INV-016 require_role/any_role test gap, INV-007 OAuth subscript propagation) | INV-015 (4 doc mismatches), INV-027 (cli.py:20 `_APP_DIR`) | Shipped Semgrep CI (PR #28) — 5 custom rules across INV-001, INV-002, INV-007, INV-021, INV-027 |
 | 2026-05-26 | iter 3 graduation: INV-002 + INV-001 to L3 full | none | none | Added 3 new Semgrep rules: `nori-sync-time-sleep-in-async`, `nori-sync-requests-import-in-services`, `nori-sync-subprocess-in-async`. `services/*` swept manually for INV-001 partner calls — zero usages. Full repo scan: 8 rules × 71 files = 0 findings. Convergence metric: 0 new classes, 0 regressions — pure mechanization work. |
+| 2026-05-26 | git/release/docs flow review | none | INV-015 (4 new instances: mike fiction in `mkdocs.yml`, VPS+rsync fiction in `docs/deployment.md`, 2 dead anchors in code_quality.md + dependencies.md) | Cleanup PR: pinned `mkdocs-material>=9.7.6` in deploy workflow, added `--strict` to `mkdocs build`, removed unused `extra.version: mike` stanza, rewrote `docs/deployment.md` Documentation site section to describe the actual Firebase + GH Actions pipeline, fixed both dead anchors, added `[Unreleased]` section to CHANGELOG. Convergence metric: 0 new classes, 4 INV-015 regressions caught manually — confirms that L3 for INV-015 remains infeasible (would have needed a docs-vs-real-infra check that no static tool can do). |

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -1,0 +1,808 @@
+# Nori Invariants Catalog
+
+> **Internal operational document. Do NOT publish.**
+> Lives in the repository root so MkDocs (which only scans `docs/`) does not
+> include it in https://nori.sembei.mx. Coverage gaps and detector maturity
+> levels are an attack map; keep them internal.
+
+## Purpose
+
+A versioned catalog of every **bug class** discovered in Nori, with stable IDs,
+CWE links, fix recipes, detector maturity, and coverage by area.
+
+The catalog is the convergence mechanism for audits. Without it, every audit
+re-discovers the same classes because the knowledge lives in CHANGELOG
+narrative + AGENTS.md prose + maintainer memory. With it:
+
+- Each new finding either matches an existing INV (regression — fix in code)
+  or is a new class (add a new INV, decide a detector strategy).
+- The next audit is split into two phases: (A) run the catalog's detectors
+  against the delta since last sweep — should trend toward zero hits; (B)
+  exploratory search for new classes — the only legitimate source of new INVs.
+- Detector maturity tracks the cost of catching each class: L1 (manual) ⇒
+  L3 (CI-enforced). Promoting L1/L2 entries to L3 is the highest-leverage
+  audit follow-up.
+
+## How to use this document
+
+- **Before shipping a security-relevant change**: scan the catalog for
+  related INVs (Ctrl-F by file path or CWE).
+- **During an audit**: run all L2 detectors (grep recipes) and verify all
+  L3 detectors are still active (Semgrep workflow green). New findings get
+  filed as either a regression of an existing INV or a new INV.
+- **After fixing a bug**: update the matching INV's coverage area and
+  regression test list. If it was a new class, create a new INV entry.
+
+## How to add a new INV
+
+1. ID is the next integer (zero-padded to 3 digits). **IDs are stable forever**
+   — never reuse, never reassign, never renumber.
+2. Find the CWE at https://cwe.mitre.org/data/definitions/. If no clean match,
+   use `Nori-specific` and explain why.
+3. Use the template below. Keep each section short — one paragraph max.
+4. If the class is mechanizable, file the Semgrep / test work as L1 → L2 → L3
+   graduation in the catalog's "Roadmap" section at the bottom.
+
+## INV template
+
+```markdown
+### INV-NNN: <Title — noun phrase>
+
+- **CWE**: CWE-XXX (description) | Nori-specific
+- **First seen**: vX.Y.Z (Round N | spot fix)
+- **Status**: Active | Mitigated | Deprecated
+- **Severity (max instance)**: HIGH | MED | LOW
+- **Bug class**: One sentence describing the pattern (not any specific instance).
+- **Fix recipe**: One sentence describing the correct pattern.
+- **Detector maturity**:
+  - L1 (manual review): yes/no
+  - L2 (scripted): command or absent
+  - L3 (mechanized): rule ID or absent
+- **Coverage by area**: which framework areas have been swept against this INV.
+- **Instances**: list of historical occurrences (version, file, one-line note).
+- **Regression tests**: pytest IDs that pin the fix.
+- **Related**: cross-links to other INV-NNN.
+```
+
+## Severity legend
+
+- **HIGH**: exploitable security boundary (auth bypass, RCE, data leak, DoS).
+- **MED**: security-adjacent hardening or correctness with security impact under stress.
+- **LOW**: defense-in-depth, docs, observability.
+
+## Detector maturity legend
+
+- **L1** — Manual review only. Knowledge is in this catalog + reviewer memory.
+- **L2** — Scripted check: a documented `rg` recipe, ad-hoc script, or test
+  pattern. Run by hand during audits; not enforced in CI.
+- **L3** — Mechanized in CI: Semgrep rule, custom pytest assertion,
+  repo-state lint, or other automatic gate that blocks merge on regression.
+
+Promotion path: every L1 in this catalog is technical debt. The audit
+roadmap below tracks graduation candidates.
+
+---
+
+## Catalog
+
+Listed in order of historical discovery (oldest first). IDs are stable.
+
+---
+
+### INV-001: Cache read-modify-write must be atomic (TOCTOU)
+
+- **CWE**: CWE-367 (Time-of-check Time-of-use Race Condition) + CWE-362 (Race Condition)
+- **First seen**: v1.18.0 (Round 4, systemic class fix)
+- **Status**: Active (recurring — sweep new sites on every release)
+- **Severity (max instance)**: HIGH
+- **Bug class**: A function does `await cache_get(key)` → modify in Python → `await cache_set(key, ...)`. Under concurrency, two callers read the same baseline, both compute the same delta, both write the same value. The counter never advances; any security gate built on top (lockouts, rate limits, dedup) is silently disabled.
+- **Fix recipe**: `cache_incr(key)` for scalar counters; `cache_atomic_update(key, fn, ttl)` for any other RMW. Both implemented in `core/cache.py` (memory: asyncio lock; Redis: Lua EVAL or WATCH/MULTI/EXEC retry).
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'cache_get|cache_set' <file>` + visual review for partner calls
+  - L3: `.semgrep/nori-rules.yml::nori-toctou-cache-read-modify-write` (WARNING, since 2026-05)
+- **Coverage by area**:
+  - `core/auth/*`: swept Round 4 + L3 active
+  - `core/http/throttle*`: swept Round 4 + L3 active
+  - `core/queue*`: swept Round 4 + L3 active
+  - `core/cache.py`: excluded from L3 (implementation site)
+  - `core/auth/session_guard.py`: excluded from L3 (read-through accelerator pattern)
+  - `services/*`: **NOT explicitly swept** against this INV
+  - User code (`app/*`, `modules/*`): out of framework scope
+- **Instances**:
+  - v1.18.0: `login_guard.record_failed_login` — `cache_get` + `cache_set` on attempts dict
+  - v1.18.0: `throttle_backends.add_timestamp` — separate `get_timestamps` + `add_timestamp`
+  - v1.21.1: `login_guard` tier-escalation `>=` vs `==` — same family
+  - v1.29.0: `cache.cache_incr` Memory backend TTL drift on existing no-TTL counter
+  - v1.32.0: memory queue unbounded fan-out (no semaphore = no TOCTOU per se, same concurrency-hazard family)
+- **Regression tests**: `test_brute_force_concurrent_attempts_trigger_lockout`, `test_attempts_above_threshold_without_lockout_do_not_re_escalate`, `test_memory_incr_does_not_apply_ttl_to_existing_no_ttl_counter`, `test_memory_queue_caps_concurrent_execution`, plus the new 50-coroutine throttle test
+- **Related**: INV-021 (task GC under concurrency), INV-025 (Redis delayed-job double-execution)
+
+---
+
+### INV-002: Sync work must not block the asyncio event loop
+
+- **CWE**: CWE-400 (Uncontrolled Resource Consumption — event loop starvation)
+- **First seen**: v1.17.0 (Round 3) — local file upload write
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: A blocking call (disk I/O, CPU-heavy crypto, network sync) runs directly inside an `async def`, freezing every other coroutine sharing that loop. Symptom: throughput collapses under load; a single slow disk or RSA refresh stalls the entire worker.
+- **Fix recipe**: Wrap the blocking call in `asyncio.to_thread(...)`. Dispatch helper for callables of unknown async-ness: `inspect.iscoroutinefunction(f)` → `await f(...)` else `await asyncio.to_thread(f, ...)`.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'async def' --files-with-matches services/ | xargs rg -n 'open\(|time\.sleep|.*\.encrypt|.*\.sign'`
+  - L3: `.semgrep/nori-rules.yml::nori-service-sync-open-in-async` (WARNING, since 2026-05). Only covers `open()` in `services/*`; other sync calls (crypto, hashing, image decoding) are still L1/L2.
+- **Coverage by area**:
+  - `services/storage_gcs.py`: swept Round 4 (RSA + cred load via to_thread)
+  - `services/*` (open() detection only): L3 since 2026-05
+  - `core/http/upload.py`: swept Round 3 (`asyncio.to_thread` for disk write)
+  - `core/auth/security.py`: swept v1.22.0 (PBKDF2 async)
+  - `core/tasks.py`: swept v1.27.0 (background dispatcher offloads sync)
+  - `core/queue_worker.py`: swept v1.30.0 (execute_payload offloads sync)
+  - Other crypto callsites (JWT signing, etc.): **NOT explicitly swept**
+- **Instances**:
+  - v1.17.0: `core/http/upload.py` write_bytes on loop
+  - v1.18.0: `services/storage_gcs.py` `_load_credentials` + `_build_jwt`
+  - v1.22.0: `core/auth/security.py` PBKDF2 hash_password / verify_password
+  - v1.27.0: `core/tasks.py` background() sync dispatch
+  - v1.30.0: `core/queue_worker.py` execute_payload sync dispatch
+- **Regression tests**: `test_hash_password_does_not_block_event_loop`, `test_background_sync_callable_does_not_block_event_loop`, `test_execute_payload_offloads_sync_callable_to_thread`
+- **Related**: INV-022 (httpx per-call adds latency same family)
+
+---
+
+### INV-003: Queue worker `func_path` must pass allow-list check (RCE defense)
+
+- **CWE**: CWE-94 (Code Injection) + CWE-915 (Improperly Controlled Dynamic Attribute)
+- **First seen**: v1.17.0 (Round 3, upgrade note 3)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: The queue payload's `func` field is used to import and invoke arbitrary Python code without restricting which modules are allowed. An attacker who can write to the queue store (compromised DB, MITM on Redis) gets RCE.
+- **Fix recipe**: Three-layer defense in `core/queue_worker.py:execute_payload`: (1) `mod_path` matches a prefix in `QUEUE_ALLOWED_MODULES`; (2) the function name is a bare identifier (`^[A-Za-z_][A-Za-z0-9_]*$`); (3) post-`getattr`, recheck `func.__module__` against the allow-list to defeat re-exports.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'importlib.import_module|getattr' core/queue_worker.py`
+  - L3: covered by behavior tests (no Semgrep rule; the rule would need to track that all three layers exist together — hard to express statically)
+- **Coverage by area**:
+  - `core/queue_worker.py`: fully covered by 3-layer test suite
+  - User-supplied serializers (custom queue drivers): users must implement the same checks if they bypass `execute_payload`
+- **Instances**:
+  - v1.17.0: initial allow-list (prefix match)
+  - v1.23.0: bare-identifier validation + `__module__` recheck to block `from os import system`
+- **Regression tests**: `test_execute_payload_rejects_dotted_func_name`, `test_execute_payload_rejects_re_exported_os_system`, plus the `os.system` / `subprocess` / `builtins.exec` rejection tests
+- **Related**: INV-019 (X-Request-ID injection — same family of "trust nothing from the network")
+
+---
+
+### INV-004: CSRF middleware must reject ambiguous request shapes
+
+- **CWE**: CWE-352 (CSRF) + CWE-400 (DoS via body buffering)
+- **First seen**: v1.17.0 (Round 3) — JSON exemption
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: A condition in the CSRF middleware intended as convenience becomes a bypass — either a Content-Type exemption that browsers can satisfy cross-origin, or body buffering that creates a DoS amplifier.
+- **Fix recipe**: (a) **No content-type exemptions** for browser-readable methods. JSON clients must send `X-CSRF-Token` header. (b) **Check the header before reading the body** so streaming and multipart uploads stay streamed. (c) Refuse `multipart/form-data` without the header (do NOT buffer to extract token). (d) Cap urlencoded body buffering at `CSRF_FORM_MAX_BODY_SIZE` (default 1 MiB).
+- **Detector maturity**:
+  - L1: yes (manual review on `core/auth/csrf.py` changes)
+  - L2: pre-merge checklist for csrf.py — verify header-first, multipart refusal, body cap intact
+  - L3: behavior tests + docs↔code mismatch caught by INV-015 manual checklist
+- **Coverage by area**:
+  - `core/auth/csrf.py`: full behavior coverage
+- **Instances**:
+  - v1.17.0: removed `application/json` short-circuit
+  - v1.22.0: multipart-without-header refused, body cap configurable
+- **Regression tests**: `test_multipart_without_header_is_refused`, `test_multipart_with_header_passes_without_buffering`, `test_form_body_cap_is_configurable`
+- **Related**: INV-015 (docs↔code coherence — body cap previously documented as 10 MB while code is 1 MiB)
+
+---
+
+### INV-005: OAuth driver must reject unverified email
+
+- **CWE**: CWE-290 (Authentication Bypass by Spoofing) + CWE-287 (Improper Authentication)
+- **First seen**: v1.17.0 (Round 3)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: An OAuth driver returns the email from the provider without checking the verification flag. An attacker registers an OAuth identity with an unverified email matching an existing account they don't own and gets logged in as the victim.
+- **Fix recipe**: Default `email = ''` when the provider reports `email_verified` is False. The raw value remains available at `profile['raw']['email']` for callers that explicitly opt in.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'email_verified|verified' services/oauth_*`
+  - L3: behavior test per driver
+- **Coverage by area**:
+  - `services/oauth_google.py`: covered
+  - `services/oauth_github.py`: GitHub returns verified-only emails by API design (`/user/emails` filters to verified); review on any provider added
+  - New OAuth drivers (any future): contract: ALWAYS check verification flag, fail closed
+- **Instances**:
+  - v1.17.0: Google OAuth driver `email = data.get('email', '') if email_verified else ''`
+- **Regression tests**: `test_get_user_profile_clears_email_when_unverified`, `test_get_user_profile_clears_email_when_verified_field_missing`
+- **Related**: INV-007 (JWT optional-claim handling — same family of "third-party assertions need defensive defaults")
+
+---
+
+### INV-006: Search/filter user input must be escaped before DSL interpolation
+
+- **CWE**: CWE-943 (Improper Neutralization of Special Elements in Data Query Logic)
+- **First seen**: v1.17.0 (Round 3)
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: User-supplied values are interpolated raw into a query DSL string without escaping, allowing operator injection (`field = "x" OR true` style) to read records the user is not authorized to see.
+- **Fix recipe**: Escape backslashes and quotes in values; validate field keys against `^[A-Za-z_][A-Za-z0-9_.\-]*$`; raise `ValueError` for invalid keys.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n "f'.*\{.*\}'" services/search_meilisearch.py` (look for unescaped f-string interpolation)
+  - L3: behavior test
+- **Coverage by area**:
+  - `services/search_meilisearch.py`: covered
+  - Future search drivers (Elasticsearch, Typesense, etc.): contract enforced via test pattern
+- **Instances**:
+  - v1.17.0: Meilisearch `_build_filter_string` raw `f'{k} = "{v}"'`
+- **Regression tests**: named in Round 3 changelog (no canonical name)
+- **Related**: none
+
+---
+
+### INV-007: JWT/OAuth optional claims must be accessed defensively
+
+- **CWE**: CWE-287 (Improper Authentication) + CWE-703 (Improper Check for Exceptional Conditions)
+- **First seen**: v1.16.0 (spot) + v1.18.0 (Round 4)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: Two distinct shapes:
+  1. A security check silently fails due to wrong abstraction access (e.g. `backend._store` introspection bypassing the cache interface, so Redis-backed revocations are silently ignored).
+  2. An auth handler treats an optional spec field as required (`payload['jti']`), so a token without that claim crashes the handler — DoS path on logout/callback.
+- **Fix recipe**: (a) Route all backend reads through the public cache API (`cache_get`), never the storage attribute. (b) Use `.get('claim')` for all RFC-optional fields; handle None explicitly.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n "payload\[" core/auth/`
+  - L3: `.semgrep/nori-rules.yml::nori-jwt-payload-required-claim` (ERROR, since 2026-05). Restricted to `core/auth/*`. Covers `jti`, `sub`, `iss`, `aud`, `nbf`.
+- **Coverage by area**:
+  - `core/auth/jwt.py`: covered (revocation + claim access)
+  - `core/auth/oauth.py`: covered
+  - `services/oauth_*`: covered (callbacks also propagate HTTPStatusError with log — see PR #28)
+  - Backend `_store` attribute access elsewhere: **NOT explicitly swept**
+- **Instances**:
+  - v1.16.0: `_is_blacklisted` read `backend._store` — only worked on MemoryBackend
+  - v1.18.0: `revoke_token` raised `ValueError` on missing `jti` (RFC-optional)
+- **Regression tests**: `test_revoke_token_blocks_verify_under_redis_backend`, plus the v1.18.0 missing-`jti` test
+- **Related**: INV-005 (OAuth unverified email — same family of "defensive defaults for third-party data")
+
+---
+
+### INV-008: Serializers must respect `protected_fields`
+
+- **CWE**: CWE-212 (Improper Removal of Sensitive Information) + CWE-200 (Information Exposure)
+- **First seen**: v1.19.0 (Round 5)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: A serialization path bypasses `protected_fields` (e.g. `NoriCollection.to_list()` falls back to `_meta.fields_map` for models without `NoriModelMixin`), emitting `password_hash`, tokens, and other secrets to JSON responses.
+- **Fix recipe**: All serialization goes through `.to_dict()`. Raise `TypeError` if a Model-shaped object lacks `to_dict()` rather than silently falling back to full field dump.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'fields_map|_meta\.' core/`
+  - L3: behavior test (`test_to_list_documents_popo_contract` v1.28.0 pins contract)
+- **Coverage by area**:
+  - `core/collection.py`: covered
+  - Manual `JSONResponse({field: value, ...})` in user code: out of scope (users must use `.to_dict()`; documented)
+- **Instances**:
+  - v1.19.0: `NoriCollection.to_list()` raised TypeError on non-NoriModelMixin Tortoise Models
+- **Regression tests**: `test_to_list_documents_popo_contract`
+- **Related**: INV-019 (CR/LF in mail / log — also a sensitive-output-control invariant)
+
+---
+
+### INV-009: Client IP must be parsed right-to-left through trusted proxies
+
+- **CWE**: CWE-348 (Use of Less Trusted Source for IP Address)
+- **First seen**: v1.19.0 (Round 5)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: Client IP taken from leftmost `X-Forwarded-For` entry. An attacker controls that header from the browser; rate limits, audit logs, and IP-based ACLs see the spoofed value.
+- **Fix recipe**: Walk `X-Forwarded-For` right-to-left, skipping each entry that matches `TRUSTED_PROXIES`. Return the first untrusted hop. Fall back to direct peer IP if all hops are trusted.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'X-Forwarded-For|x_forwarded_for|XFF' core/`
+  - L3: behavior tests (spoofed-leftmost, multi-proxy chain, all-trusted fallback)
+- **Coverage by area**:
+  - `core/http/request_id.py` (or equivalent IP helper): covered
+  - `core/audit.py`: covered (uses the helper)
+  - `core/http/throttle.py`: covered (uses the helper)
+- **Instances**:
+  - v1.19.0: `get_client_ip()` used `split(',')[0]`
+- **Regression tests**: spoofed-leftmost test (named in Round 5 changelog)
+- **Related**: INV-029 (trusted-proxies misconfig warning — operator-side counterpart)
+
+---
+
+### INV-010: Superuser role must be configurable, not hardcoded
+
+- **CWE**: CWE-798 (Hard-coded Credentials) + CWE-269 (Improper Privilege Management)
+- **First seen**: v1.20.0 (Round 6)
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: A privileged role name is hardcoded as a string literal in auth decorators. Any session containing that string gets total access; the name cannot be renamed or disabled.
+- **Fix recipe**: Read role name from config: `_superuser_role()` → `config.get('SUPERUSER_ROLE', 'admin')`. Allow `''` to disable bypass entirely.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n "'admin'" core/auth/`
+  - L3: behavior test on `SUPERUSER_ROLE='' disables bypass`
+- **Coverage by area**:
+  - `core/auth/decorators.py`: covered (3 decorators: `require_role`, `require_any_role`, `require_permission`)
+  - Other hardcoded role/permission literals: **NOT explicitly swept**
+- **Instances**:
+  - v1.20.0: `_superuser_role()` reads config
+- **Regression tests**: existing ACL tests updated
+- **Related**: none
+
+---
+
+### INV-011: Mail headers must reject CR/LF (header injection)
+
+- **CWE**: CWE-93 (Improper Neutralization of CRLF Sequences)
+- **First seen**: v1.21.0 (Round 7)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: User-supplied strings (subject, From, recipients) flow directly into MIME header fields without sanitizing CR/LF, enabling header injection (Bcc exfiltration, reply-to hijack).
+- **Fix recipe**: `_reject_header_injection(value)` raises `ValueError` on any `\r` or `\n` in header-bound strings. Applied to subject, From, To, Cc, Bcc, Reply-To.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'add_header|MIMEText|MIMEMultipart' core/mail.py services/mail_*`
+  - L3: behavior test per header
+- **Coverage by area**:
+  - `core/mail.py`: covered
+  - `services/mail_resend.py`: covered (passes through, provider rejects on its side too — defense in depth)
+- **Instances**:
+  - v1.21.0: `_build_message()` rejected CR/LF in all header inputs
+- **Regression tests**: CR/LF-in-mail tests (Round 7 suite)
+- **Related**: INV-012 (log injection — same CRLF class)
+
+---
+
+### INV-012: User-controlled headers must be validated before adoption into logs
+
+- **CWE**: CWE-117 (Improper Output Neutralization for Logs)
+- **First seen**: v1.21.0 (Round 7)
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: A request-supplied header (e.g. `X-Request-ID`) is adopted into the log record verbatim. An attacker injects CR/LF + crafted log lines to forge audit entries or break log parsers.
+- **Fix recipe**: Validate against an allow-list pattern (`^[A-Za-z0-9_\-]{1,64}$`). On mismatch, drop and generate fresh UUID.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'request.headers.get' core/http/request_id.py core/audit.py core/logger.py`
+  - L3: behavior test (`test_request_id_cr_lf_rejection`)
+- **Coverage by area**:
+  - `core/http/request_id.py`: covered
+  - Other headers adopted into logs (User-Agent, custom): **NOT explicitly swept**
+- **Instances**:
+  - v1.21.0: X-Request-ID validation
+- **Regression tests**: `test_request_id_cr_lf_rejection`
+- **Related**: INV-011, INV-029
+
+---
+
+### INV-013: Archive extraction must guard against zip-slip
+
+- **CWE**: CWE-22 (Path Traversal)
+- **First seen**: v1.21.0 (Round 7)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: Archive (zip/tar) member paths are extracted without validating that the resolved destination stays within the target directory. A member named `../../etc/cron.d/x` writes outside the extraction root.
+- **Fix recipe**: `_safe_extract_path(target_dir, member_name)` resolves the destination and refuses any path that does not start with the resolved target. Apply per member, never `extractall()` blind.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'extractall|extract\(' core/ docs/`
+  - L3: behavior test (`test_framework_update_refuses_zip_slip_member`)
+- **Coverage by area**:
+  - `core/cli.py:framework_update`: covered
+  - `docs/install.py`: covered
+  - Any future archive extraction: must use `_safe_extract` pattern
+- **Instances**:
+  - v1.21.0: framework:update + installer
+- **Regression tests**: `test_framework_update_refuses_zip_slip_member`
+- **Related**: INV-024 (framework_update non-atomic staging — adjacent)
+
+---
+
+### INV-014: Upload size limits must be enforced during streaming, not after
+
+- **CWE**: CWE-400 (Uncontrolled Resource Consumption)
+- **First seen**: v1.21.0 (Round 7)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: File uploads are fully buffered into memory before size checks are enforced, so a single 10 GB upload exhausts worker memory before the check fires.
+- **Fix recipe**: `_read_capped(stream, max_size)` reads in 64 KB chunks, aborts on excess. Spool to `SpooledTemporaryFile(8 MB)` (rolls to disk past threshold). Storage drivers accept file-like chunked iterators, never bytes.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'await .*\.read\(\)' core/http/upload.py services/storage_*`
+  - L3: behavior tests
+- **Coverage by area**:
+  - `core/http/upload.py`: covered
+  - `services/storage_s3.py`, `storage_gcs.py`: covered (streaming protocol)
+  - Future storage drivers: contract enforced via protocol tests
+- **Instances**:
+  - v1.21.0: `save_upload` chunked read
+  - v1.23.0: full driver protocol refactor (file-like, not bytes)
+- **Regression tests**: `test_save_upload_passes_file_like_to_driver`, `test_save_upload_streaming_handles_payload_above_ram_threshold`
+- **Related**: INV-017 (SVG XSS — adjacent upload hardening)
+
+---
+
+### INV-015: Docs and code must stay coherent (manual review on high-leverage files)
+
+- **CWE**: Nori-specific (no clean CWE — "the class of bug ruff/mypy cannot catch")
+- **First seen**: v1.15.4 (CORS+SecurityHeaders middleware order)
+- **Status**: Active (recurring — each release surfaces some drift)
+- **Severity (max instance)**: MED (the v1.15.4 instance caused CORS preflight responses to ship without security headers — actually HIGH-impact, but the class median is MED)
+- **Bug class**: A comment, docstring, or docs page describes behavior X; the code does Y. Both compile cleanly. ruff, mypy, and high coverage pass. Only manual review surfaces it.
+- **Fix recipe**: Before shipping a change to high-leverage files (list below), grep `docs/**/*.md` for matching snippets, read surrounding prose, verify code comment + code body match. Determine canonical side (sometimes the docs are right and the code is the bug).
+- **Detector maturity**:
+  - L1: yes (manual review + exploration agent prompt)
+  - L2: pre-merge grep recipe on high-leverage files (below)
+  - L3: **not feasible** — the 2026-05 audit found 4 mismatches at once; a regex CI check would go stale and false-positive. The cost-effective approach is per-PR review.
+- **High-leverage files** (touching these requires docs+code review in the same change):
+  - `rootsystem/application/asgi.py` (middleware order, lifespan)
+  - `rootsystem/application/settings.py` (defaults that affect lifecycle/ownership)
+  - `rootsystem/application/core/cli.py` (CLI commands described in `docs/cli.md`)
+  - `rootsystem/application/core/auth/csrf.py`, `core/http/validation.py` (rule precedence)
+  - `rootsystem/application/core/queue_worker.py`, `core/queue.py` (allow-list contract)
+  - `_FRAMEWORK_DIRS` / `_FRAMEWORK_FILES` in `core/cli.py` (ownership in `docs/architecture.md`)
+- **Coverage by area**: covered by per-PR discipline + per-release sweep
+- **Instances**:
+  - v1.15.4: CORS at `insert(1, ...)` while docs documented `insert(2, ...)`
+  - 2026-05 audit: 4 mismatches (CSRF JSON exemption, body cap 10MB vs 1MiB, SECRET_KEY validation claim, exempt_paths type)
+- **Regression tests**: `test_middleware_order_with_cors_keeps_security_headers_outside_cors` pins the specific v1.15.4 invariant; no general lint
+- **Related**: every other INV (the docs side of every INV should match the code)
+
+---
+
+### INV-016: Session revocation must work end-to-end (active-user gate + version counter)
+
+- **CWE**: CWE-613 (Insufficient Session Expiration) + CWE-287 (Improper Authentication)
+- **First seen**: v1.31.0 (active-user gate) + v1.33.0 (version counter)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: A user is deactivated or has a session revoked, but their cookie remains valid until `max_age` expires. Stolen sessions cannot be invalidated server-side.
+- **Fix recipe**: Two complementary checks: (a) `load_permissions` queries `User.is_active` before populating permissions; returns `[]` if deactivated. (b) Per-user integer version counter in DB+cache; bumped by `invalidate_session()`; all auth decorators check `session_version` against live counter before role/permission logic. Cache writes use explicit TTL.
+- **Detector maturity**:
+  - L1: yes
+  - L2: per-decorator audit on every change to `core/auth/decorators.py`
+  - L3: behavior tests for all 4 session-aware decorators (`login_required`, `require_role`, `require_any_role`, `require_permission`) — completed in PR #28
+- **Coverage by area**:
+  - `core/auth/decorators.py`: covered
+  - `core/auth/session_guard.py`: covered (circuit breaker + TTL)
+  - User session storage (Starlette default vs custom): contract documented in `docs/authentication.md`
+- **Instances**:
+  - v1.31.0: `load_permissions` `is_active` gate
+  - v1.33.0: per-user `session_version` counter
+  - v1.33.1: explicit TTL on `session_guard` cache writes
+- **Regression tests**: `test_load_permissions_refuses_inactive_user`, `test_login_required_denies_when_session_version_revoked`, `test_require_role_denies_when_session_version_revoked`, `test_require_any_role_denies_when_session_version_revoked`, `test_require_permission_denies_when_session_revoked`, `test_cache_writes_respect_configurable_ttl`, plus 18 more in `test_session_guard.py`
+- **Related**: INV-007 (JWT revocation — same family of "auth must support fast invalidation")
+
+---
+
+### INV-017: SVG uploads must be content-scanned for active content
+
+- **CWE**: CWE-79 (Stored XSS) + CWE-434 (Unrestricted Upload of File with Dangerous Type)
+- **First seen**: v1.34.0
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: SVG files are accepted by the default upload allowlist and served inline (XML media type). SVG can contain `<script>`, `<foreignObject>`, `<iframe>`, and `on*` event handlers that execute in the host origin — stored XSS.
+- **Fix recipe**: Two layers: (a) SVG removed from the default `allowed_types` allowlist (`_UNSAFE_BY_DEFAULT`); users must opt in explicitly. (b) When opted in, `_validate_svg_content` scans the first 256 KB and rejects `<script>`, `<foreignObject>`, `<iframe>`, `on*` attributes (case-insensitive).
+- **Detector maturity**:
+  - L1: yes
+  - L2: review on every change to `_MIME_MAP` or `_validate_svg_content`
+  - L3: 13 behavior tests
+- **Coverage by area**:
+  - `core/http/upload.py`: covered
+  - User code that bypasses `save_upload` (raw `request.form()`): out of framework scope; documented
+- **Instances**:
+  - v1.34.0: SVG removed from default + content scan when opted in
+- **Regression tests**: `test_default_allowed_types_excludes_svg`, `test_svg_content_rejects_script_tag`, `test_save_upload_default_rejects_svg_extension`, `test_save_upload_svg_xss_blocked_when_opted_in`
+- **Related**: INV-014 (upload size limits — same family)
+
+---
+
+### INV-018: Numeric validation must reject NaN and Inf
+
+- **CWE**: CWE-704 (Incorrect Type Conversion) + CWE-20 (Improper Input Validation)
+- **First seen**: v1.22.0
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: `float('nan')` and `float('inf')` satisfy `>= min` and `<= max` checks (IEEE 754 comparison semantics return False for both sides). User submitting `amount=nan` bypasses any min/max range check.
+- **Fix recipe**: Explicit rejection of NaN and Inf in both `min_value` and `max_value` rules. Standard test: `math.isnan(v) or math.isinf(v)`.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'min_value|max_value|float\(' core/http/validation.py`
+  - L3: behavior tests
+- **Coverage by area**:
+  - `core/http/validation.py`: covered
+- **Instances**:
+  - v1.22.0: explicit NaN/Inf rejection in `min_value`/`max_value`
+- **Regression tests**: `test_min_value_rejects_nan`, `test_max_value_rejects_nan`, `test_min_value_rejects_inf`, `test_max_value_rejects_neg_inf`
+- **Related**: none
+
+---
+
+### INV-019: Dependency CVE gate must block ship
+
+- **CWE**: CWE-1035 (OWASP A06:2021 — Vulnerable and Outdated Components)
+- **First seen**: v1.11.0 (Python floor bump cleared 6 CVEs)
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class**: A dependency pinned to a version with known CVEs; fix sometimes requires raising the Python floor or breaking-version migration.
+- **Fix recipe**: `pip-audit` runs in CI on every push and PR. Documented `--ignore-vuln` allow-list with per-entry justification (see `.github/workflows/audit.yml`).
+- **Detector maturity**:
+  - L1: no
+  - L2: no
+  - L3: `.github/workflows/audit.yml` — `pip-audit` blocks merge on any new CVE
+- **Coverage by area**:
+  - `requirements.txt` + `requirements.nori.txt` + `requirements-dev.txt`: covered
+  - Transitive deps: covered (pip-audit walks transitively)
+- **Instances**:
+  - v1.11.0: Python 3.9 floor bump + dep updates (cleared CVE-2026-24486 arbitrary file write + 5 others)
+- **Regression tests**: covered by CI gate (no pytest needed)
+- **Related**: none
+
+---
+
+### INV-020: In-flight async background work must be tracked for graceful shutdown
+
+- **CWE**: CWE-778 (Insufficient Logging) — for audit case; CWE-362 (Race / data loss) more broadly
+- **First seen**: v1.24.0 (audit task loss)
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: An `async def` operation is launched via `asyncio.create_task` but the returned Task reference is discarded. The event loop holds only a weak reference; the task can be garbage-collected mid-await, or dropped on SIGTERM/lifespan teardown. Symptoms: silent audit log gaps; silent dropped background jobs.
+- **Fix recipe**: Module-level `set[asyncio.Task]`. Every `create_task` is added; `task.add_done_callback(_set.discard)` cleans up. `flush_pending(timeout=N)` registered with ASGI lifespan to await all pending before teardown.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'asyncio\.create_task|asyncio\.ensure_future' core/`
+  - L3: behavior tests per site (audit, memory queue)
+- **Coverage by area**:
+  - `core/audit.py`: covered (audit task loss)
+  - `core/queue.py:_memory_handler`: covered (memory queue task GC)
+  - Other create_task sites: **NOT systematically swept**
+- **Instances**:
+  - v1.24.0: `core/audit.py` flush_pending on lifespan
+  - v1.30.0: `_memory_tasks` set + add_done_callback in core/queue.py
+- **Regression tests**: `test_audit_registers_pending_task_for_lifespan_flush`, `test_flush_pending_awaits_in_flight_audit_writes`, `test_memory_handler_holds_strong_reference_to_task`
+- **Related**: INV-001 (cache TOCTOU — both are concurrency invariants)
+
+---
+
+### INV-021: httpx clients must be reused per service driver
+
+- **CWE**: CWE-400 (Uncontrolled Resource Consumption — socket exhaustion + TLS handshake cost)
+- **First seen**: v1.18.0 (Round 4)
+- **Status**: Active
+- **Severity (max instance)**: MED (performance-with-security-impact: fd exhaustion DoSes other requests)
+- **Bug class**: A new `httpx.AsyncClient` is constructed per request (`async with httpx.AsyncClient() as c:`). Every constructor opens a fresh TCP+TLS handshake (~100-200ms over WAN), exhausts socket descriptors under load.
+- **Fix recipe**: One module-level `_client: httpx.AsyncClient | None` per service driver. Lazy `_get_client()` initializes once and registers `shutdown()` with `core.lifecycle.register_shutdown(...)` so the ASGI lifespan closes the pool cleanly.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'httpx\.AsyncClient\(' services/`
+  - L3: `.semgrep/nori-rules.yml::nori-service-httpx-per-call-asyncclient` (ERROR, since 2026-05). Restricted to `services/*`.
+- **Coverage by area**:
+  - `services/*`: all 6 drivers covered (mail_resend, storage_gcs, storage_s3, oauth_github, oauth_google, search_meilisearch)
+  - Future drivers: L3 catches at PR time
+- **Instances**:
+  - v1.18.0: Round 4 finding + defensive sweep across all 6 drivers
+- **Regression tests**: lifecycle registry tests in v1.27.0 (`test_run_shutdown_handlers_invokes_each_in_order`)
+- **Related**: INV-002 (sync I/O hygiene — both are "service driver performance discipline")
+
+---
+
+### INV-022: Sync `validate()` must fail loud on async-only rules
+
+- **CWE**: CWE-20 (Improper Input Validation — constraint unenforced)
+- **First seen**: v1.16.0
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: Calling sync `validate()` with a rule that requires database I/O (e.g. `unique:table,column`) silently no-ops the rule. The constraint is unenforced; duplicate emails/usernames slip through to the DB unique-index error or worse.
+- **Fix recipe**: Sync `validate()` raises `ValueError` listing offending async-rule fields with explicit direction: "call `validate_async()` instead".
+- **Detector maturity**:
+  - L1: yes
+  - L2: review on every change to `core/http/validation.py:_check_rule`
+  - L3: behavior tests
+- **Coverage by area**:
+  - `core/http/validation.py`: covered
+- **Instances**:
+  - v1.16.0: `unique` rule raises in sync `validate()`
+- **Regression tests**: `test_unique_raises_in_sync_validate`, `test_validate_lists_all_async_violations`
+- **Related**: none
+
+---
+
+### INV-023: `framework:update` must be atomic (stage-and-swap)
+
+- **CWE**: CWE-367 (TOCTOU on framework install) + CWE-400 (availability loss on mid-update failure)
+- **First seen**: v1.23.0
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: Update performs `rmtree(target) → copytree(new)` sequentially. A mid-copy failure (disk full, signal, network blip on remote source) leaves the framework directory empty, breaking the next import system-wide.
+- **Fix recipe**: Stage-and-swap: copy to `<dir>.new`, then `os.replace(<dir>.new, <dir>)` atomically after all stages succeed. Keep `<dir>.old` until end for rollback.
+- **Detector maturity**:
+  - L1: yes
+  - L2: review on every change to `core/cli.py:framework_update`
+  - L3: behavior test
+- **Coverage by area**:
+  - `core/cli.py:framework_update`: covered
+- **Instances**:
+  - v1.23.0: stage-and-swap implementation
+- **Regression tests**: `test_framework_update_rolls_back_when_staging_fails`
+- **Related**: INV-013 (zip-slip — same framework_update path)
+
+---
+
+### INV-024: Redis multi-step operations must be wrapped in Lua
+
+- **CWE**: CWE-362 (Race Condition — silent double-execution)
+- **First seen**: v1.17.0 (Round 3) — delayed job promotion
+- **Status**: Active
+- **Severity (max instance)**: MED (silent double-execution: double charges, double notifications)
+- **Bug class**: A "promotion" or "atomic shift" against Redis is implemented as multiple round-trips (`ZRANGEBYSCORE` → `LPUSH` → `ZREM`). Two concurrent workers both promote the same job before either removes it from the sorted set.
+- **Fix recipe**: Single `EVAL` with a Lua script holding the entire critical section. Redis guarantees single-threaded Lua execution.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'redis_client\.[a-z]+\(.*\).*\n.*redis_client' core/` (look for sequential Redis ops)
+  - L3: behavior test (lupa-backed for fakeredis)
+- **Coverage by area**:
+  - `core/queue_worker.py:_work_redis`: covered (single EVAL)
+  - `core/cache.py:cache_atomic_update`: covered (WATCH/MULTI/EXEC retry; alternative to Lua for general RMW)
+  - Other multi-step Redis sites: **NOT explicitly swept**
+- **Instances**:
+  - v1.17.0: Redis delayed-job promotion via Lua
+- **Regression tests**: lupa-backed Redis tests (v1.18.0 batch)
+- **Related**: INV-001 (TOCTOU cache — same concurrency family, different layer)
+
+---
+
+### INV-025: Installer must verify checksum of downloaded archive
+
+- **CWE**: CWE-494 (Download of Code Without Integrity Check)
+- **First seen**: v1.17.0 (Round 3)
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: Installer downloads a release archive without verifying integrity, vulnerable to tag mutation, mirror compromise, or re-tag attacks.
+- **Fix recipe**: `--checksum H` CLI flag accepts SHA-256; installer always prints computed SHA-256 of downloaded archive; aborts on mismatch.
+- **Detector maturity**:
+  - L1: yes
+  - L2: review on every change to `docs/install.py`
+  - L3: documented in `docs/installation.md`; no pytest (installer is one-shot)
+- **Coverage by area**:
+  - `docs/install.py`: covered
+  - `core/cli.py:framework_update`: future opportunity — currently relies on GitHub TLS but does not verify
+- **Instances**:
+  - v1.17.0: `--checksum` flag added
+- **Regression tests**: none (installer one-shot; manual end-to-end on release)
+- **Related**: INV-013, INV-023
+
+---
+
+### INV-026: CLI subprocess scripts must call `configure(settings)` before importing user code
+
+- **CWE**: Nori-specific
+- **First seen**: v1.10.5 (routes_list fix)
+- **Status**: Active
+- **Severity (max instance)**: MED (broken command on launch; not exploit)
+- **Bug class**: A CLI command spawns a Python subprocess (`python -c "<script>"` or `python -m asyncio` with PYTHONSTARTUP) that imports user `routes`/`modules`/`models`. Without `configure(settings)` first, any user module that touches `config.X` / `templates.env` / framework state at import time crashes with `RuntimeError: Nori config not initialised`.
+- **Fix recipe**: Every subprocess script starts with:
+  ```python
+  import sys
+  sys.path.insert(0, '.')
+  import settings
+  from core.conf import configure
+  configure(settings)
+  # ... then user imports
+  ```
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'subprocess\.run.*python' core/cli.py` then inspect script body
+  - L3: per-command behavior test (`test_routes_list_configures_settings_before_importing_routes`, `test_migrate_fresh_drop_subprocess_calls_configure`, `test_shell_pythonstartup_configures_and_imports_models_before_init`)
+- **Coverage by area**:
+  - `core/cli.py`: `routes_list`, `migrate_init`, `migrate_upgrade`, `migrate_fresh`, `db_seed`, `queue_work`, `shell` — all covered
+  - aerich subprocesses (which don't run inline Python): use `env=_quiet_env()` to suppress warnings
+- **Instances**:
+  - v1.10.5: routes_list fix
+  - v1.22.0: migrate:fresh drop subprocess
+  - 2026-05 (PR #28): `nori shell` (also added `import models` + dropped `asyncio.get_event_loop()`)
+- **Regression tests**: see L3 above
+- **Related**: INV-027 (CWD-independent paths — adjacent CLI hygiene)
+
+---
+
+### INV-027: File and module path resolution must be CWD-independent
+
+- **CWE**: Nori-specific (correctness; potential CWE-22 adjacent in some cases)
+- **First seen**: AGENTS.md §7 — codified after several similar incidents
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: `pathlib.Path('something')` or `os.path.join('rootsystem', '...')` resolves relative to the caller's CWD. `nori.py` adds `rootsystem/application/` to `sys.path` but does NOT `chdir` into it. Invoking `python3 /abs/path/nori.py migrate:upgrade` from `/tmp` breaks with FileNotFoundError.
+- **Fix recipe**: Anchor all paths to the module file:
+  ```python
+  pathlib.Path(__file__).resolve().parent.parent / 'something'
+  ```
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n "Path\(['\"][a-z]" core/ services/` (literal-string Path arguments)
+  - L3: `.semgrep/nori-rules.yml::nori-cli-cwd-relative-path` (ERROR, since 2026-05). Restricted to `core/cli.py`. Does NOT catch `os.path.join('literal', ...)`.
+- **Coverage by area**:
+  - `core/cli.py`: L3 active for `Path(...)`; `os.path.join` form still L1
+  - `core/`, `services/` more broadly: L2 only
+- **Instances**:
+  - Multiple historical CLI fixes per AGENTS.md §7
+  - 2026-05 audit flagged `_APP_DIR = os.path.join('rootsystem', 'application')` in `cli.py:20` as still CWD-relative — pending fix
+- **Regression tests**: indirectly covered by per-command tests; no dedicated path-resolution test
+- **Related**: INV-026
+
+---
+
+### INV-028: Repo state itself can be a bug (ship-time invariants)
+
+- **CWE**: Nori-specific
+- **First seen**: v1.10.3 (`.gitkeep` incident)
+- **Status**: Active
+- **Severity (max instance)**: MED
+- **Bug class**: Some bugs are not in code but in committed files (the v1.8.0 → v1.10.2 incident: leftover `.gitkeep` files silently broke `migrate:init` for two releases). Unit tests of the affected function passed because the test env didn't have the bad files.
+- **Fix recipe**: When fixing "the repo shouldn't ship X", add a static repo-state assertion alongside the function fix.
+- **Detector maturity**:
+  - L1: no
+  - L2: no
+  - L3: repo-state pytest assertions (see `test_repo_does_not_ship_migrations_dir`)
+- **Coverage by area**:
+  - `rootsystem/application/migrations/` non-existence: L3 active
+  - Other ship-time invariants (mkdocs nav valid, CLI commands documented, `.env` not committed): **NOT YET covered** — see audit roadmap
+- **Instances**:
+  - v1.10.3: `migrations/` dir not shipped
+- **Regression tests**: `test_repo_does_not_ship_migrations_dir`
+- **Related**: INV-015 (docs↔code coherence — adjacent)
+
+---
+
+### INV-029: New settings must default via `config.get(key, default)`
+
+- **CWE**: Nori-specific (backwards-compatibility)
+- **First seen**: codified after multiple add-setting commits
+- **Status**: Active
+- **Severity (max instance)**: LOW (breakage on upgrade for users who haven't set the new key)
+- **Bug class**: Code accesses a new user-overridable setting via `config.SETTING` (attribute access). Existing projects that haven't added the key to `settings.py` crash on upgrade.
+- **Fix recipe**: Read with `config.get('SETTING', default_value)`. Default must match the previous hardcoded behavior so existing projects keep working.
+- **Detector maturity**:
+  - L1: yes
+  - L2: `rg -n 'config\.[A-Z_]+' core/` and compare against documented settings
+  - L3: not feasible (false positives on settings that ARE always present)
+- **Coverage by area**:
+  - All new settings since v1.10.x: discipline maintained per AGENTS.md §7
+- **Instances**:
+  - LOGIN_URL, FORBIDDEN_URL, PERMISSIONS_TTL (multiple v1.x releases)
+- **Regression tests**: per-feature tests assert the default kicks in when the setting is absent
+- **Related**: none
+
+---
+
+## Roadmap — L1/L2 entries to graduate to L3
+
+These are the highest-leverage Semgrep/test mechanizations remaining. Sorted by impact × frequency.
+
+| Priority | INV | Current | Target | Why |
+|----------|-----|---------|--------|-----|
+| HIGH | INV-002 | L3 partial (open() in services/ only) | L3 full | Extend rule to other sync calls (crypto, time.sleep, file walks) across `core/` and `services/` |
+| HIGH | INV-001 | L3 partial (services/* not swept) | L3 full | Sweep `services/*` for `cache_get`+`cache_set` partner patterns |
+| MED | INV-007 | L3 partial (subscript only, jti/sub/iss/aud/nbf) | L3 full | Add `cache_get` `_store` backend bypass detection |
+| MED | INV-027 | L3 partial (Path() in cli.py only) | L3 full | Extend to `os.path.join` and broaden to `core/`, `services/` |
+| MED | INV-020 | L1/L2 | L3 | Detect `asyncio.create_task` without `add_done_callback` |
+| MED | INV-013 | L3 (per site) | L3 (rule) | Generalize zip-slip pattern detection rule |
+| LOW | INV-019 (audit reflex) | L3 already (pip-audit) | — | Already complete |
+
+## Roadmap — new ship-time lints (INV-028 family)
+
+- Each `mkdocs.yml` nav entry maps to an existing `.md` file (regression for nav rot)
+- Each `add_parser(...)` in `cli.py main()` has a corresponding entry in `docs/cli.md`
+- `rootsystem/application/.env` is not committed
+- `rootsystem/static/.gitkeep` content is exactly empty (catches accidental contents)
+
+## Audit log
+
+When you complete an audit pass, append here:
+
+| Date | Scope | New INVs | Regressions of existing INVs | Notes |
+|------|-------|----------|------------------------------|-------|
+| 2026-05-25 | full sweep (code + docs + tests) | none (all 4 Criticals matched existing INVs: INV-004 docs side, INV-026 shell, INV-016 require_role/any_role test gap, INV-007 OAuth subscript propagation) | INV-015 (4 doc mismatches), INV-027 (cli.py:20 `_APP_DIR`) | Shipped Semgrep CI (PR #28) — 5 custom rules across INV-001, INV-002, INV-007, INV-021, INV-027 |

--- a/docs/code_quality.md
+++ b/docs/code_quality.md
@@ -126,7 +126,7 @@ python3 nori.py framework:check-config
 python3 nori.py framework:check-config --version 1.15.2
 ```
 
-The output is a categorized diff (added upstream / changed / local-only) with full paths like `tool.coverage.report.fail_under`. Read-only — you decide what to port. See the [CLI reference](cli.md#framework-check-config) for the full command shape.
+The output is a categorized diff (added upstream / changed / local-only) with full paths like `tool.coverage.report.fail_under`. Read-only — you decide what to port. See the [CLI reference](cli.md#frameworkcheck-config) for the full command shape.
 
 ### Adding stricter rules
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -108,7 +108,7 @@ pip resolves to `==0.37.2`. No conflict with the framework file.
 
 If your site was created on Nori ≤ 1.6, the upgrade to 1.7 takes care of the wiring:
 
-1. `python3 nori.py framework:update` — brings in `requirements.nori.txt` and replaces the framework directories. On sites coming from ≤ 1.6, the `-r` injection into your `requirements.txt` happens on the next run (see [observability.md](observability.md#upgrading-an-existing-site) for the reason). Run `framework:update --force` once to apply.
+1. `python3 nori.py framework:update` — brings in `requirements.nori.txt` and replaces the framework directories. On sites coming from ≤ 1.6, the `-r` injection into your `requirements.txt` happens on the next run. Run `framework:update --force` once to apply.
 2. From 1.7 onwards, patches apply automatically on the same update that ships them — the patch system reloads itself from the newly installed core before running.
 3. After patching, run `pip install -r requirements.txt` to refresh your environment.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -431,50 +431,36 @@ For sites above 5M visits/month, consider horizontal scaling (multiple servers b
 
 ## Documentation site
 
-Nori includes a [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) configuration for generating a documentation website from the `docs/` directory.
+The official Nori docs at <https://nori.sembei.mx> are built from the `docs/` directory using [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) and published automatically on every push to `main`.
 
-### Build and deploy
+### Pipeline (Firebase Hosting + GitHub Actions)
 
-```bash
-# Install (one-time)
-pip install mkdocs-material
+`.github/workflows/deploy-docs.yml` runs on any push to `main` that touches `docs/**` or `mkdocs.yml`. No manual deploy step is required. The workflow:
 
-# Build the static site
-mkdocs build --strict
+1. Installs `mkdocs-material` (pinned to `>=9.7.6` — bump deliberately).
+2. Runs `mkdocs build --strict` so nav / file / theme warnings fail CI rather than ship silently.
+3. Publishes the resulting `site/` directory to Firebase Hosting (project `sembei-websites`, target `nori-docs`, channel `live`).
 
-# Deploy to your server
-rsync -avz --delete site/ yourserver:/srv/websites/nori-docs/
-```
+`firebase.json` controls cache headers (`max-age=2592000` on static assets); `.firebaserc` ties the local project to `sembei-websites`. Both are tracked in the repo so CI and local behaviour stay in sync.
 
 ### Local preview
 
 ```bash
+pip install mkdocs-material
 mkdocs serve
 # Open http://localhost:8000
 ```
 
-### Apache configuration
-
-```apache
-<VirtualHost *:80>
-    ServerName nori.yourdomain.com
-    DocumentRoot /srv/websites/nori-docs
-
-    <Directory /srv/websites/nori-docs>
-        Options -Indexes +FollowSymLinks
-        AllowOverride None
-        Require all granted
-    </Directory>
-</VirtualHost>
-```
-
-Add SSL with Certbot: `sudo certbot --apache -d nori.yourdomain.com`
-
-### Manual deploy
-
-Build the docs locally and deploy via rsync (or any method of your choice):
+### Local build (mirrors CI)
 
 ```bash
-mkdocs build --clean
-rsync -avz --delete site/ yourserver:/path/to/docs/
+mkdocs build --strict
 ```
+
+Use this to validate doc changes before pushing — same `--strict` flag, same theme version when your venv matches the workflow pin.
+
+### Self-hosting on a different stack
+
+The build output is plain static HTML, so any static host serves it (Nginx, Apache, Caddy, S3+CloudFront, Cloudflare Pages, Netlify, etc.). Build with `mkdocs build` and serve the resulting `site/` directory — no MkDocs runtime needed at serve time.
+
+If you fork this docs setup for a different domain, edit `mkdocs.yml` (`site_url`, `site_name`) and supply your own publish workflow. The Firebase action in `deploy-docs.yml` is the only Nori-specific piece; everything else is upstream MkDocs.

--- a/docs/forms_validation.md
+++ b/docs/forms_validation.md
@@ -23,7 +23,9 @@ Every form that makes a `POST` request must include a CSRF token. Since `csrf_fi
 
 If the CSRF token is missing or invalid on a state-changing request (POST, PUT, DELETE, PATCH), the middleware returns `403 Forbidden`.
 
-> **JSON APIs are exempt**: Requests with `Content-Type: application/json` skip CSRF validation entirely. Browsers enforce CORS for cross-origin JSON requests, so the CSRF vector does not apply. API authentication should use JWT tokens instead (see [Authentication](authentication.md)).
+> **JSON requests**: Requests with `Content-Type: application/json` are **not exempt** — they must send the CSRF token in the `X-CSRF-Token` header. The middleware does not parse JSON bodies, so the `_csrf_token` form field path does not apply; the header is the only accepted channel. Sending JSON without the header returns `403 Forbidden`.
+>
+> **JWT-protected API endpoints** (using `@token_required` — see [Authentication](authentication.md)) are unaffected by CSRF, because the `Authorization: Bearer …` header is itself unforgeable from a cross-origin browser context.
 
 ## Pipe-Separated Declarative Validation (`validate`)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,9 +97,11 @@ extra_css:
   - stylesheets/custom.css
 
 extra:
-  version:
-    provider: mike
-    default: stable
+  # mike (the multi-version docs plugin) was declared here historically
+  # but never installed or invoked anywhere in the pipeline — the deploy
+  # workflow runs a single `mkdocs build` and ships the flat site/ tree.
+  # Removed to keep the config honest. Re-add only when we genuinely
+  # publish multiple versions side-by-side and install mike in CI.
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/sembeimx/nori

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,10 @@ exclude = [
     ".venv",
     "venv",
     "tests",
+    # scripts/ holds maintainer utility programs (release cutter, etc.).
+    # The user-facing contract is the script's argparse + module docstring;
+    # internal helpers are intentionally terse. They are not framework API.
+    "scripts",
 ]
 ignore-init-module = true       # __init__.py files are typically re-export shims
 ignore-init-method = true       # constructors are described by their class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ max-complexity = 10
 # wrapper). Each layer's complexity comes from supporting many injectable
 # parameter shapes (request, form, json, query, path); flattening duplicates.
 "rootsystem/application/core/http/inject.py" = ["C901"]
+# scripts/release.py orchestrates git, ruff, mypy, pytest, and semgrep via
+# subprocess. The arguments are constructed from a closed set of literals
+# plus the version arg (validated against ^\d+\.\d+\.\d+$ before any
+# subprocess fires). Same exemption shape as core/cli.py.
+"scripts/release.py" = ["S603", "S607"]
 
 [tool.ruff.format]
 quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ extend-exclude = [
     ".venv",
     "venv",
     "__pycache__",
+    # Synthetic positive/negative trigger files for Semgrep custom rules.
+    # The cache_get / cache_set names are intentionally undefined (the
+    # patterns are what Semgrep matches on, not runnable code).
+    ".semgrep",
 ]
 
 [tool.ruff.lint]

--- a/rootsystem/application/core/auth/oauth.py
+++ b/rootsystem/application/core/auth/oauth.py
@@ -26,7 +26,14 @@ import base64
 import hashlib
 import hmac
 import secrets
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from core.logger import get_logger
+
+if TYPE_CHECKING:
+    import httpx
+
+_log = get_logger('oauth')
 
 _STATE_SESSION_KEY = '_oauth_state'
 _PKCE_SESSION_KEY = '_oauth_pkce_verifier'
@@ -104,3 +111,39 @@ def get_pkce_verifier(session: dict[str, Any]) -> str | None:
     """
     verifier: str | None = session.pop(_PKCE_SESSION_KEY, None)
     return verifier
+
+
+def raise_for_status_logged(response: httpx.Response, provider: str, stage: str) -> None:
+    """Call ``response.raise_for_status()`` with a WARNING log on failure.
+
+    OAuth provider rejections (expired code, replayed code, network blips)
+    surface to the application as ``httpx.HTTPStatusError`` and become 500s
+    unless the controller catches them. Logging the status + a truncated body
+    BEFORE re-raising gives the operator the bare minimum to debug — without
+    leaking secrets that providers do not put in error bodies (codes, IDs).
+
+    Args:
+        response: The httpx response to validate.
+        provider: Short provider name for the log line (``'github'``, ``'google'``).
+        stage: Which step in the flow failed (``'token exchange'``, ``'user profile'``).
+
+    Raises:
+        httpx.HTTPStatusError: Always re-raised after logging — the caller still
+            owns the error path (return a 400/redirect/etc.).
+    """
+    try:
+        response.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 — re-raised after logging
+        body = ''
+        try:
+            body = response.text[:200]
+        except Exception:  # noqa: BLE001, S110 — body might be binary/unreadable
+            pass
+        _log.warning(
+            'OAuth %s %s failed: HTTP %s — %s',
+            provider,
+            stage,
+            response.status_code,
+            body,
+        )
+        raise exc

--- a/rootsystem/application/core/cli.py
+++ b/rootsystem/application/core/cli.py
@@ -71,14 +71,30 @@ def shell() -> None:
         import sys
         sys.path.insert(0, '.')
 
+        # Order matters here, do NOT reshuffle:
+        # 1. settings must load before configure() so config.X is bindable.
+        # 2. configure() must run before any framework module that touches
+        #    config at import time (jinja, templates, registered drivers).
+        # 3. `import models` is what triggers register_model() inside
+        #    models/__init__.py — without it, _models is always {} and
+        #    no user-defined class is bound at the prompt.
+        # 4. Only then is Tortoise.init safe to call.
         import settings
-        from tortoise import Tortoise
+        from core.conf import configure
+        configure(settings)
+
+        import models  # noqa: F401  -- side-effect import: populates _models
         from core.registry import _models
+        from tortoise import Tortoise
 
         # Boot Tortoise synchronously before the REPL prompt appears.
-        asyncio.get_event_loop().run_until_complete(
-            Tortoise.init(config=settings.TORTOISE_ORM)
-        )
+        # new_event_loop + set_event_loop avoids the asyncio.get_event_loop
+        # DeprecationWarning on 3.10/3.12 and the RuntimeError on 3.14+
+        # that fires when PYTHONSTARTUP runs before python -m asyncio
+        # binds a loop of its own.
+        _loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_loop)
+        _loop.run_until_complete(Tortoise.init(config=settings.TORTOISE_ORM))
 
         # Bind every registered model as a top-level name.
         globals().update(_models)

--- a/rootsystem/application/core/queue.py
+++ b/rootsystem/application/core/queue.py
@@ -15,7 +15,7 @@ from core.logger import get_logger
 from core.registry import get_model
 
 _log = get_logger('queue')
-_DRIVERS = {}
+_DRIVERS: dict[str, Callable] = {}
 
 # Strong references to in-flight memory-driver tasks. ``asyncio.create_task``
 # returns a Task that the event loop holds only by weak reference, so an

--- a/rootsystem/application/services/oauth_github.py
+++ b/rootsystem/application/services/oauth_github.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 from urllib.parse import urlencode
 
 import httpx
-from core.auth.oauth import generate_state, validate_state
+from core.auth.oauth import generate_state, raise_for_status_logged, validate_state
 from core.conf import config
 
 _AUTHORIZE_URL = 'https://github.com/login/oauth/authorize'
@@ -144,7 +144,7 @@ async def handle_callback(
         },
         headers={'Accept': 'application/json'},
     )
-    token_resp.raise_for_status()
+    raise_for_status_logged(token_resp, 'github', 'token exchange')
     access_token = token_resp.json()['access_token']
 
     return await get_user_profile(access_token)
@@ -174,14 +174,14 @@ async def get_user_profile(access_token: str) -> dict:
 
     client = _get_client()
     user_resp = await client.get(_USER_URL, headers=headers)
-    user_resp.raise_for_status()
+    raise_for_status_logged(user_resp, 'github', 'user profile')
     user = user_resp.json()
 
     # Resolve email: use /user endpoint first, fall back to /user/emails
     email = user.get('email') or ''
     if not email:
         emails_resp = await client.get(_EMAILS_URL, headers=headers)
-        emails_resp.raise_for_status()
+        raise_for_status_logged(emails_resp, 'github', 'user emails')
         for entry in emails_resp.json():
             if entry.get('primary') and entry.get('verified'):
                 email = entry['email']

--- a/rootsystem/application/services/oauth_google.py
+++ b/rootsystem/application/services/oauth_google.py
@@ -40,7 +40,13 @@ from __future__ import annotations
 from urllib.parse import urlencode
 
 import httpx
-from core.auth.oauth import generate_pkce_verifier, generate_state, get_pkce_verifier, validate_state
+from core.auth.oauth import (
+    generate_pkce_verifier,
+    generate_state,
+    get_pkce_verifier,
+    raise_for_status_logged,
+    validate_state,
+)
 from core.conf import config
 
 _AUTHORIZE_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
@@ -151,7 +157,7 @@ async def handle_callback(
             'code_verifier': code_verifier,
         },
     )
-    token_resp.raise_for_status()
+    raise_for_status_logged(token_resp, 'google', 'token exchange')
     tokens = token_resp.json()
 
     return await get_user_profile(tokens['access_token'])
@@ -183,7 +189,7 @@ async def get_user_profile(access_token: str) -> dict:
         _USERINFO_URL,
         headers={'Authorization': f'Bearer {access_token}'},
     )
-    resp.raise_for_status()
+    raise_for_status_logged(resp, 'google', 'user info')
     data = resp.json()
 
     email_verified = bool(data.get('email_verified', False))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Cut a Nori release.
+
+Replaces the historical 8-step manual sequence (bump version.py, write
+CHANGELOG, commit, push, tag, push tag, write release notes, gh release
+create) with a single validated command. Pure stdlib so it can run from
+any clone without venv activation.
+
+Usage
+-----
+
+    scripts/release.py 1.35.0                # cut release 1.35.0
+    scripts/release.py 1.35.0 --dry-run      # validate only, do not mutate
+    scripts/release.py 1.35.0 --skip-tests   # skip the local CI gate
+    scripts/release.py 1.35.0 --unsigned     # produce an unsigned tag
+
+The CI workflow `.github/workflows/release.yml` consumes the same parser:
+
+    scripts/release.py --extract-changelog 1.35.0   # prints the [1.35.0] section to stdout
+
+Pipeline
+--------
+
+1. Pre-flight validations (no mutations yet):
+   - semver shape
+   - working tree clean
+   - on main, up-to-date with origin/main
+   - version.py distinct from target
+   - CHANGELOG has a non-empty [Unreleased] section
+   - tag v<version> does not exist (local or remote)
+   - local CI green (ruff, mypy, pytest, semgrep) unless --skip-tests
+
+2. Atomic mutations:
+   - version.py: __version__ = '<target>'
+   - CHANGELOG: rename [Unreleased] header to [<target>] — <today>,
+     insert fresh empty [Unreleased] block above
+
+3. Commit + signed tag + push:
+   - git commit -m "release: v<target>"
+   - git tag -s v<target> (unless --unsigned)
+   - git push origin main
+   - git push origin v<target>
+
+After the tag lands on origin, .github/workflows/release.yml fires,
+extracts the [<target>] section as the release body, and creates the
+GitHub Release. sbom.yml then fires on release: published and attaches
+the SBOM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_FILE = REPO_ROOT / 'rootsystem' / 'application' / 'core' / 'version.py'
+CHANGELOG = REPO_ROOT / 'CHANGELOG.md'
+VENV_PYTHON = REPO_ROOT / '.venv' / 'bin' / 'python'
+
+SEMVER_RE = re.compile(r'^(\d+)\.(\d+)\.(\d+)$')
+VERSION_LINE_RE = re.compile(r"(__version__\s*=\s*['\"])([^'\"]+)(['\"])")
+UNRELEASED_HEADER = '## [Unreleased]'
+UNRELEASED_PLACEHOLDER = (
+    '_Nothing accumulated yet — add entries here as they ship to '
+    '`main` so the next release cut is just a rename + date stamp._'
+)
+FRESH_UNRELEASED_BLOCK = f'## [Unreleased]\n\n{UNRELEASED_PLACEHOLDER}\n'
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def die(msg: str, code: int = 1) -> None:
+    print(f'error: {msg}', file=sys.stderr)
+    sys.exit(code)
+
+
+def step(msg: str) -> None:
+    print(f'  {msg}')
+
+
+def header(msg: str) -> None:
+    print(f'\n{msg}')
+
+
+def run_git(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(['git', *args], capture_output=True, text=True, check=check, cwd=REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Parser / mutator helpers — pure functions, fully tested
+# ---------------------------------------------------------------------------
+
+
+def parse_semver(version: str) -> tuple[int, int, int]:
+    """Validate the version string and return (major, minor, patch).
+
+    Rejects v-prefixed input, pre-release/build metadata, and anything that
+    is not strict MAJOR.MINOR.PATCH digits.
+    """
+    m = SEMVER_RE.match(version)
+    if not m:
+        die(f'version must be MAJOR.MINOR.PATCH (got {version!r})')
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def read_version_file(text: str) -> str:
+    """Extract __version__ from a version.py source string."""
+    m = VERSION_LINE_RE.search(text)
+    if not m:
+        raise ValueError('could not parse __version__ assignment')
+    return m.group(2)
+
+
+def write_version_file(text: str, new: str) -> str:
+    """Return version.py source with __version__ replaced by new."""
+    if not VERSION_LINE_RE.search(text):
+        raise ValueError('no __version__ assignment to replace')
+    return VERSION_LINE_RE.sub(rf'\g<1>{new}\g<3>', text, count=1)
+
+
+def extract_section(changelog: str, header_text: str) -> tuple[str, int, int]:
+    """Return (body, start_index, end_index) for a CHANGELOG section.
+
+    The body is everything BETWEEN the header line and the next `## ` /
+    `---` separator, stripped of surrounding blank lines. start_index and
+    end_index span from the header line through the trailing separator.
+    """
+    lines = changelog.splitlines(keepends=True)
+    # Find the header line.
+    start = None
+    for i, line in enumerate(lines):
+        if line.rstrip() == header_text:
+            start = i
+            break
+    if start is None:
+        raise ValueError(f'section not found: {header_text!r}')
+    # Find the next `## ` header that ends the section.
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if lines[j].startswith('## '):
+            end = j
+            break
+    # Body: lines between header+1 and end, minus trailing horizontal rule
+    # and minus surrounding blank lines.
+    body_lines = lines[start + 1 : end]
+    # Strip a trailing `---\n` separator if present.
+    while body_lines and body_lines[-1].strip() in ('', '---'):
+        body_lines.pop()
+    # Strip leading blank lines.
+    while body_lines and body_lines[0].strip() == '':
+        body_lines.pop(0)
+    return ''.join(body_lines), start, end
+
+
+def is_unreleased_empty(body: str) -> bool:
+    """True if the [Unreleased] body is only the placeholder paragraph."""
+    return body.strip() == UNRELEASED_PLACEHOLDER
+
+
+def transform_changelog(text: str, version: str, today: str) -> tuple[str, str]:
+    """Rename [Unreleased] to [<version>] — <today> and insert a fresh
+    [Unreleased] block above.
+
+    Returns (new_changelog_text, released_body). released_body is the body
+    of the renamed section, ready to be the GitHub Release notes.
+    """
+    body, start, end = extract_section(text, UNRELEASED_HEADER)
+    if is_unreleased_empty(body):
+        raise ValueError(
+            '[Unreleased] section is empty (only the placeholder paragraph). '
+            'Add at least one changelog entry before cutting a release.'
+        )
+    lines = text.splitlines(keepends=True)
+    # Replace the [Unreleased] header line.
+    lines[start] = f'## [{version}] — {today}\n'
+    # Insert a fresh [Unreleased] block above the renamed section.
+    insertion = f'{FRESH_UNRELEASED_BLOCK}\n---\n\n'
+    lines.insert(start, insertion)
+    return ''.join(lines), body
+
+
+def extract_release_body(text: str, version: str) -> str:
+    """For the CI workflow: get the body of the [<version>] section.
+
+    Versioned headers carry a date suffix (`## [1.34.0] — 2026-04-30`), so
+    a literal-equality match like extract_section() uses would miss them.
+    This helper walks lines with startswith() instead.
+    """
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.startswith(f'## [{version}]'):
+            end = len(lines)
+            for j in range(i + 1, len(lines)):
+                if lines[j].startswith('## '):
+                    end = j
+                    break
+            body_lines = lines[i + 1 : end]
+            while body_lines and body_lines[-1].strip() in ('', '---'):
+                body_lines.pop()
+            while body_lines and body_lines[0].strip() == '':
+                body_lines.pop(0)
+            return ''.join(body_lines)
+    raise ValueError(f'section not found: [{version}]')
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight validations
+# ---------------------------------------------------------------------------
+
+
+def assert_working_tree_clean() -> None:
+    if run_git('diff', '--quiet', check=False).returncode != 0:
+        die('working tree has unstaged changes — commit or stash first')
+    if run_git('diff', '--cached', '--quiet', check=False).returncode != 0:
+        die('working tree has staged changes — commit or unstage first')
+
+
+def assert_on_main_up_to_date() -> None:
+    branch = run_git('branch', '--show-current').stdout.strip()
+    if branch != 'main':
+        die(f'must be on main to cut a release (currently on {branch!r})')
+    run_git('fetch', 'origin', 'main')
+    local = run_git('rev-parse', 'main').stdout.strip()
+    remote = run_git('rev-parse', 'origin/main').stdout.strip()
+    if local != remote:
+        die('local main is not up-to-date with origin/main — pull (or push) first')
+
+
+def assert_version_distinct(current: str, target: str) -> None:
+    if current == target:
+        die(f'version.py already says {target} — nothing to cut')
+
+
+def assert_tag_absent(tag: str) -> None:
+    local = run_git('tag', '-l', tag).stdout.strip()
+    if local:
+        die(f'tag {tag} already exists locally — delete it or choose a new version')
+    remote = run_git('ls-remote', '--tags', 'origin', tag).stdout.strip()
+    if remote:
+        die(f'tag {tag} already exists on origin — choose a new version')
+
+
+def assert_local_ci_green() -> None:
+    """Run ruff, mypy, pytest, semgrep against the working tree. Each
+    step echoes its progress; the first non-zero exit aborts.
+    """
+    venv_bin = REPO_ROOT / '.venv' / 'bin'
+
+    def venv_or_path(tool: str) -> str:
+        candidate = venv_bin / tool
+        if candidate.exists():
+            return str(candidate)
+        found = shutil.which(tool)
+        if not found:
+            die(f'{tool} not found — install dev dependencies or pass --skip-tests')
+        return found
+
+    env_for_tests = {
+        'DEBUG': 'true',
+        'DB_ENGINE': 'sqlite',
+        'DB_NAME': ':memory:',
+        'SECRET_KEY': 'release-script-test-key',
+    }
+
+    checks: list[tuple[str, list[str], dict[str, str] | None]] = [
+        ('ruff check', [venv_or_path('ruff'), 'check', '.'], None),
+        ('ruff format --check', [venv_or_path('ruff'), 'format', '--check', '.'], None),
+        ('mypy', [venv_or_path('mypy')], None),
+        (
+            'pytest',
+            [venv_or_path('pytest'), 'tests/', '-q', '--no-header'],
+            env_for_tests,
+        ),
+        (
+            'semgrep (custom rules)',
+            [
+                venv_or_path('semgrep'),
+                'scan',
+                '--config',
+                '.semgrep/nori-rules.yml',
+                '--metrics=off',
+                '--disable-version-check',
+                '--error',
+            ],
+            None,
+        ),
+    ]
+    import os as _os
+
+    for name, cmd, extra_env in checks:
+        step(f'running {name} …')
+        env = dict(_os.environ)
+        if extra_env:
+            env.update(extra_env)
+        result = subprocess.run(cmd, cwd=REPO_ROOT, env=env)
+        if result.returncode != 0:
+            die(f'{name} failed — fix or pass --skip-tests')
+    step('local CI suite green')
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
+
+
+def apply_mutations(target: str, today: str) -> str:
+    """Write version.py + CHANGELOG. Return the released section body
+    (used downstream by the CI workflow via --extract-changelog).
+    """
+    version_text = VERSION_FILE.read_text()
+    new_version_text = write_version_file(version_text, target)
+    changelog_text = CHANGELOG.read_text()
+    new_changelog_text, released_body = transform_changelog(changelog_text, target, today)
+    VERSION_FILE.write_text(new_version_text)
+    CHANGELOG.write_text(new_changelog_text)
+    return released_body
+
+
+def commit_and_tag(target: str, *, signed: bool) -> None:
+    run_git('add', str(VERSION_FILE), str(CHANGELOG))
+    run_git('commit', '-m', f'release: v{target}')
+    tag_args = ['tag']
+    if signed:
+        tag_args.append('-s')
+    tag_args += ['-m', f'v{target}', f'v{target}']
+    run_git(*tag_args)
+
+
+def push_main_and_tag(target: str) -> None:
+    run_git('push', 'origin', 'main')
+    run_git('push', 'origin', f'v{target}')
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def cli_extract_changelog(version: str) -> int:
+    """--extract-changelog: print the [<version>] section body to stdout.
+
+    Called by .github/workflows/release.yml. Exits 1 if the section is
+    missing so the workflow fails loudly rather than creating an empty
+    GitHub Release.
+    """
+    parse_semver(version)
+    try:
+        body = extract_release_body(CHANGELOG.read_text(), version)
+    except ValueError as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 1
+    sys.stdout.write(body)
+    return 0
+
+
+def cli_cut_release(args: argparse.Namespace) -> int:
+    target = args.version
+    parse_semver(target)
+    tag = f'v{target}'
+    today = dt.date.today().isoformat()
+
+    header('Pre-flight checks')
+    step(f'semver: {target}')
+
+    assert_working_tree_clean()
+    step('working tree clean')
+
+    assert_on_main_up_to_date()
+    step('on main, up-to-date with origin/main')
+
+    current = read_version_file(VERSION_FILE.read_text())
+    assert_version_distinct(current, target)
+    step(f'version.py is {current} — will bump to {target}')
+
+    body, _start, _end = extract_section(CHANGELOG.read_text(), UNRELEASED_HEADER)
+    if is_unreleased_empty(body):
+        die('[Unreleased] section is empty — add changelog entries before cutting')
+    step(f'CHANGELOG [Unreleased] has {len(body.splitlines())} lines of content')
+
+    assert_tag_absent(tag)
+    step(f'tag {tag} does not exist (local + remote)')
+
+    if args.skip_tests:
+        step('skipping local CI suite (--skip-tests)')
+    else:
+        assert_local_ci_green()
+
+    if args.dry_run:
+        header('Dry run — no mutations, no push')
+        return 0
+
+    header('Mutations')
+    apply_mutations(target, today)
+    step(f'version.py → {target}')
+    step(f'CHANGELOG: [Unreleased] renamed to [{target}] — {today} + fresh [Unreleased] inserted')
+
+    commit_and_tag(target, signed=not args.unsigned)
+    step(f'commit: release: v{target}')
+    step(f'{"signed " if not args.unsigned else ""}tag {tag}')
+
+    header('Push')
+    push_main_and_tag(target)
+    step('pushed main + tag')
+    step(f'.github/workflows/release.yml will now create the GitHub Release for {tag}')
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description='Cut a Nori release. See module docstring for the full pipeline.',
+    )
+    parser.add_argument(
+        '--extract-changelog',
+        metavar='VERSION',
+        help='Print the body of CHANGELOG section [VERSION] to stdout, then exit. '
+        'Used by the release workflow to seed GH Release notes.',
+    )
+    parser.add_argument('version', nargs='?', help='Target version, MAJOR.MINOR.PATCH')
+    parser.add_argument('--dry-run', action='store_true', help='Validate only, do not mutate')
+    parser.add_argument(
+        '--skip-tests',
+        action='store_true',
+        help='Skip the local CI suite gate (ruff, mypy, pytest, semgrep)',
+    )
+    parser.add_argument(
+        '--unsigned',
+        action='store_true',
+        help='Produce an unsigned tag. Default is `git tag -s` (GPG-signed).',
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.extract_changelog:
+        return cli_extract_changelog(args.extract_changelog)
+    if not args.version:
+        parser.error('version is required (or pass --extract-changelog VERSION)')
+    return cli_cut_release(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_core/test_acl.py
+++ b/tests/test_core/test_acl.py
@@ -827,7 +827,7 @@ async def test_require_any_role_denies_when_session_version_revoked(monkeypatch)
     resp = await MultiRoleController().moderate(req)
     assert resp.status_code == 401, (
         'require_any_role must deny when session_version is stale — even if '
-        "the role still matches one of the listed roles, the session is revoked"
+        'the role still matches one of the listed roles, the session is revoked'
     )
 
 

--- a/tests/test_core/test_acl.py
+++ b/tests/test_core/test_acl.py
@@ -752,6 +752,86 @@ async def test_require_permission_denies_when_session_revoked(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_require_role_denies_when_session_version_revoked(monkeypatch):
+    """End-to-end: ``require_role`` calls ``check_session_version`` before
+    the role comparison. Without this test, breaking the decorator's gate
+    call would leave a revoked editor with full edit access until cookie
+    expiry — caught by no other test in the suite (audit 2026-05-25 #3)."""
+    from types import SimpleNamespace
+
+    import core.auth.session_guard as sg
+    from core.auth.decorators import require_role
+    from core.conf import config
+
+    monkeypatch.setattr(
+        config,
+        '_settings',
+        SimpleNamespace(SESSION_VERSION_CHECK=True),
+    )
+    sg._reset_circuit()
+
+    async def fake_cache_get(key):
+        return 99  # admin bumped the version
+
+    monkeypatch.setattr(sg, 'cache_get', fake_cache_get)
+    monkeypatch.setattr(sg, 'audit', lambda *a, **kw: None)
+
+    class RoleController:
+        @require_role('editor')
+        async def edit(self, request):
+            return JSONResponse({'ok': True})
+
+    req = FakeRequest(user_id=1, role='editor')
+    req.session['session_version'] = 5  # stale
+
+    resp = await RoleController().edit(req)
+    assert resp.status_code == 401, (
+        'require_role must deny when session_version is stale — even if the '
+        'role itself still matches, the session is revoked'
+    )
+
+
+@pytest.mark.asyncio
+async def test_require_any_role_denies_when_session_version_revoked(monkeypatch):
+    """End-to-end: ``require_any_role`` calls ``check_session_version`` before
+    the role-membership comparison. Without this test, breaking the gate
+    call would leave a revoked moderator with admin-or-moderator access
+    until cookie expiry (audit 2026-05-25 #3)."""
+    from types import SimpleNamespace
+
+    import core.auth.session_guard as sg
+    from core.auth.decorators import require_any_role
+    from core.conf import config
+
+    monkeypatch.setattr(
+        config,
+        '_settings',
+        SimpleNamespace(SESSION_VERSION_CHECK=True),
+    )
+    sg._reset_circuit()
+
+    async def fake_cache_get(key):
+        return 99  # admin bumped the version
+
+    monkeypatch.setattr(sg, 'cache_get', fake_cache_get)
+    monkeypatch.setattr(sg, 'audit', lambda *a, **kw: None)
+
+    class MultiRoleController:
+        @require_any_role('admin', 'moderator')
+        async def moderate(self, request):
+            return JSONResponse({'ok': True})
+
+    req = FakeRequest(user_id=1, role='moderator')
+    req.session['session_version'] = 5  # stale
+
+    resp = await MultiRoleController().moderate(req)
+    assert resp.status_code == 401, (
+        'require_any_role must deny when session_version is stale — even if '
+        "the role still matches one of the listed roles, the session is revoked"
+    )
+
+
+@pytest.mark.asyncio
 async def test_load_permissions_gate_query_error_falls_through(monkeypatch, caplog):
     """If ``User.get_or_none`` itself raises (transient DB error,
     custom Manager that doesn't expose the method), the gate must

--- a/tests/test_core/test_cli.py
+++ b/tests/test_core/test_cli.py
@@ -496,6 +496,75 @@ def test_shell_swallows_keyboard_interrupt_and_cleans_startup_file():
         cli.shell()  # no raise
 
 
+def test_shell_pythonstartup_configures_and_imports_models_before_init():
+    """The shell PYTHONSTARTUP script must satisfy three invariants:
+
+    1. configure(settings) is called before any framework state is touched —
+       otherwise user code that reads config at import time crashes with
+       RuntimeError: Nori config not initialised (same class as the
+       routes_list / migrate_fresh fixes documented in CLAUDE.md §7).
+    2. `import models` runs BEFORE `from core.registry import _models`,
+       so register_model() side effects in models/__init__.py have populated
+       the registry. Otherwise _models is always {} and the REPL exposes
+       no user-defined class.
+    3. asyncio.get_event_loop() is not used — deprecated since 3.10 and
+       raises RuntimeError on 3.14+ when PYTHONSTARTUP runs before
+       `python -m asyncio` binds a loop.
+
+    Audit 2026-05-25 #2.
+    """
+    from unittest.mock import MagicMock
+
+    captured = {}
+
+    def fake_run(_args, **kwargs):
+        # Read the startup script before the shell()'s finally clause unlinks it.
+        startup_path = kwargs.get('env', {}).get('PYTHONSTARTUP')
+        if startup_path:
+            with open(startup_path) as f:
+                captured['script'] = f.read()
+        return MagicMock(returncode=0)
+
+    with patch('core.cli.subprocess.run', side_effect=fake_run):
+        cli.shell()
+
+    # Strip comments so the order assertions reflect executable statements
+    # only — the script's own header comment legitimately mentions `import
+    # models` and `configure(settings)`, which would confuse str.index().
+    script = '\n'.join(
+        line for line in captured['script'].splitlines() if not line.lstrip().startswith('#')
+    )
+
+    # (1) configure(settings) is present.
+    assert 'configure(settings)' in script, 'shell must initialise Nori config'
+
+    # (2) import models must run BEFORE from core.registry import _models.
+    assert 'import models' in script, (
+        'shell must import the user models package to populate _models via register_model() side effects'
+    )
+    models_idx = script.index('import models')
+    registry_idx = script.index('from core.registry import _models')
+    assert models_idx < registry_idx, (
+        '`import models` must run BEFORE `from core.registry import _models` — '
+        'otherwise _models is always {} and the REPL exposes no model classes'
+    )
+
+    # (3) configure(settings) must run BEFORE `import models`, because user
+    # model modules typically import framework code that reads config at
+    # import time (templates.env, jinja globals, etc.).
+    configure_idx = script.index('configure(settings)')
+    assert configure_idx < models_idx, (
+        'configure(settings) must run BEFORE `import models` — user model modules '
+        'may transitively import framework code that reads config at import time'
+    )
+
+    # (4) No deprecated asyncio.get_event_loop().
+    assert 'asyncio.get_event_loop()' not in script, (
+        'asyncio.get_event_loop() is deprecated since 3.10 and raises in 3.14+; '
+        'use asyncio.new_event_loop() + asyncio.set_event_loop() instead'
+    )
+
+
 # ---------------------------------------------------------------------------
 # _get_current_version
 # ---------------------------------------------------------------------------

--- a/tests/test_core/test_cli.py
+++ b/tests/test_core/test_cli.py
@@ -531,9 +531,7 @@ def test_shell_pythonstartup_configures_and_imports_models_before_init():
     # Strip comments so the order assertions reflect executable statements
     # only — the script's own header comment legitimately mentions `import
     # models` and `configure(settings)`, which would confuse str.index().
-    script = '\n'.join(
-        line for line in captured['script'].splitlines() if not line.lstrip().startswith('#')
-    )
+    script = '\n'.join(line for line in captured['script'].splitlines() if not line.lstrip().startswith('#'))
 
     # (1) configure(settings) is present.
     assert 'configure(settings)' in script, 'shell must initialise Nori config'

--- a/tests/test_oauth_core.py
+++ b/tests/test_oauth_core.py
@@ -163,7 +163,6 @@ def test_raise_for_status_logged_logs_and_reraises_on_4xx(caplog):
 
     import httpx
     import pytest as _pytest
-
     from core.auth.oauth import raise_for_status_logged
 
     response = MagicMock()
@@ -197,7 +196,6 @@ def test_raise_for_status_logged_truncates_long_body(caplog):
 
     import httpx
     import pytest as _pytest
-
     from core.auth.oauth import raise_for_status_logged
 
     response = MagicMock()

--- a/tests/test_oauth_core.py
+++ b/tests/test_oauth_core.py
@@ -130,3 +130,94 @@ def test_get_pkce_verifier_single_use():
     second = get_pkce_verifier(session)
     assert first is not None
     assert second is None
+
+
+# -- raise_for_status_logged ------------------------------------------------
+
+
+def test_raise_for_status_logged_noop_on_success(caplog):
+    """A 2xx response passes through silently — no log, no raise."""
+    import logging
+    from unittest.mock import MagicMock
+
+    from core.auth.oauth import raise_for_status_logged
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock(return_value=None)
+    response.status_code = 200
+
+    logging.getLogger('nori').propagate = True
+    with caplog.at_level(logging.WARNING, logger='nori.oauth'):
+        raise_for_status_logged(response, 'github', 'token exchange')
+
+    assert caplog.records == [], 'no log expected on 2xx'
+
+
+def test_raise_for_status_logged_logs_and_reraises_on_4xx(caplog):
+    """On HTTPStatusError, a WARNING with provider, stage, status, and a
+    truncated body is emitted BEFORE re-raising. The contract for OAuth
+    drivers is that the error keeps propagating to the caller — the log
+    is purely operational debuggability (audit 2026-05-25 #4)."""
+    import logging
+    from unittest.mock import MagicMock
+
+    import httpx
+    import pytest as _pytest
+
+    from core.auth.oauth import raise_for_status_logged
+
+    response = MagicMock()
+    response.status_code = 400
+    response.text = 'bad_verification_code: The provided code is invalid.'
+    response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            message='400 Bad Request',
+            request=MagicMock(),
+            response=response,
+        )
+    )
+
+    logging.getLogger('nori').propagate = True
+    with caplog.at_level(logging.WARNING, logger='nori.oauth'):
+        with _pytest.raises(httpx.HTTPStatusError):
+            raise_for_status_logged(response, 'github', 'token exchange')
+
+    matching = [r for r in caplog.records if 'OAuth github token exchange failed' in r.getMessage()]
+    assert matching, 'expected a WARNING that names the provider and the stage'
+    msg = matching[0].getMessage()
+    assert '400' in msg, 'log must include the HTTP status code'
+    assert 'bad_verification_code' in msg, 'log must include a truncated response body for debugging'
+
+
+def test_raise_for_status_logged_truncates_long_body(caplog):
+    """The logged body is capped at 200 chars so a 10MB error page does not
+    flood the log line."""
+    import logging
+    from unittest.mock import MagicMock
+
+    import httpx
+    import pytest as _pytest
+
+    from core.auth.oauth import raise_for_status_logged
+
+    response = MagicMock()
+    response.status_code = 500
+    response.text = 'A' * 5000
+    response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            message='500 Internal Server Error',
+            request=MagicMock(),
+            response=response,
+        )
+    )
+
+    logging.getLogger('nori').propagate = True
+    with caplog.at_level(logging.WARNING, logger='nori.oauth'):
+        with _pytest.raises(httpx.HTTPStatusError):
+            raise_for_status_logged(response, 'google', 'user info')
+
+    msg = next(r.getMessage() for r in caplog.records if 'OAuth google user info failed' in r.getMessage())
+    # The body slice is 200 chars; the log format adds the prefix, so the
+    # total line stays well under 1KB regardless of upstream response size.
+    body_in_msg = msg.split(' — ', 1)[1]
+    assert len(body_in_msg) <= 250

--- a/tests/test_oauth_github.py
+++ b/tests/test_oauth_github.py
@@ -100,6 +100,55 @@ async def test_handle_callback_invalid_state():
 
 
 @pytest.mark.asyncio
+async def test_handle_callback_propagates_httpstatuserror_on_token_exchange_failure(caplog):
+    """When GitHub rejects the authorization code (expired, replayed,
+    revoked OAuth app), the token POST returns 4xx and raise_for_status
+    raises httpx.HTTPStatusError. handle_callback must propagate this to
+    the caller (the controller decides whether to show 'try again' or
+    log out), and a WARNING with the status must hit the operational log
+    so on-call can see WHY a redirect loop is happening. Audit 2026-05-25 #4.
+    """
+    import logging
+
+    import httpx
+    from core.auth.oauth import generate_state
+    from services.oauth_github import handle_callback
+
+    session = _make_session()
+    state = generate_state(session)
+
+    token_response = MagicMock()
+    token_response.status_code = 400
+    token_response.text = '{"error":"bad_verification_code"}'
+    token_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            message='400 Bad Request',
+            request=MagicMock(),
+            response=token_response,
+        )
+    )
+    mock_client = AsyncMock()
+    mock_client.post.return_value = token_response
+
+    logging.getLogger('nori').propagate = True
+    with patch('services.oauth_github._get_client', return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger='nori.oauth'):
+            with pytest.raises(httpx.HTTPStatusError):
+                await handle_callback(
+                    session,
+                    code='gh-bad-code',
+                    redirect_uri='https://example.com/cb',
+                    state=state,
+                )
+
+    matching = [r for r in caplog.records if 'OAuth github token exchange failed' in r.getMessage()]
+    assert matching, 'expected a WARNING that names the provider and the token-exchange stage'
+    msg = matching[0].getMessage()
+    assert '400' in msg
+    assert 'bad_verification_code' in msg
+
+
+@pytest.mark.asyncio
 async def test_handle_callback_exchanges_code():
     from core.auth.oauth import generate_state
     from services.oauth_github import _TOKEN_URL, handle_callback

--- a/tests/test_oauth_google.py
+++ b/tests/test_oauth_google.py
@@ -93,6 +93,54 @@ async def test_handle_callback_invalid_state():
 
 
 @pytest.mark.asyncio
+async def test_handle_callback_propagates_httpstatuserror_on_token_exchange_failure(caplog):
+    """When Google rejects the authorization code (expired, replayed, or
+    PKCE verifier mismatch), the token POST returns 4xx and raise_for_status
+    raises httpx.HTTPStatusError. handle_callback must propagate this to
+    the caller and emit a WARNING that names the stage. Audit 2026-05-25 #4.
+    """
+    import logging
+
+    import httpx
+    from core.auth.oauth import generate_pkce_verifier, generate_state
+    from services.oauth_google import handle_callback
+
+    session = _make_session()
+    state = generate_state(session)
+    generate_pkce_verifier(session)
+
+    token_response = MagicMock()
+    token_response.status_code = 400
+    token_response.text = '{"error":"invalid_grant"}'
+    token_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            message='400 Bad Request',
+            request=MagicMock(),
+            response=token_response,
+        )
+    )
+    mock_client = AsyncMock()
+    mock_client.post.return_value = token_response
+
+    logging.getLogger('nori').propagate = True
+    with patch('services.oauth_google._get_client', return_value=mock_client):
+        with caplog.at_level(logging.WARNING, logger='nori.oauth'):
+            with pytest.raises(httpx.HTTPStatusError):
+                await handle_callback(
+                    session,
+                    code='google-bad-code',
+                    redirect_uri='https://example.com/cb',
+                    state=state,
+                )
+
+    matching = [r for r in caplog.records if 'OAuth google token exchange failed' in r.getMessage()]
+    assert matching, 'expected a WARNING that names the provider and the token-exchange stage'
+    msg = matching[0].getMessage()
+    assert '400' in msg
+    assert 'invalid_grant' in msg
+
+
+@pytest.mark.asyncio
 async def test_handle_callback_exchanges_code():
     from core.auth.oauth import generate_pkce_verifier, generate_state
     from services.oauth_google import _TOKEN_URL, handle_callback

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,271 @@
+"""Tests for scripts/release.py.
+
+Scope: the pure parser/mutator helpers (parse_semver, version-file
+read/write, CHANGELOG section extraction and transformation). The git
+and subprocess layer is NOT tested here — the script's --dry-run path
+covers that at the integration level on every real release.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load scripts/release.py as a module without installing it. Plain importlib
+# keeps the test file in the existing tests/ tree without any path hack.
+_RELEASE_PATH = Path(__file__).resolve().parents[1] / 'scripts' / 'release.py'
+_spec = importlib.util.spec_from_file_location('nori_release_script', _RELEASE_PATH)
+assert _spec is not None and _spec.loader is not None
+release = importlib.util.module_from_spec(_spec)
+sys.modules['nori_release_script'] = release
+_spec.loader.exec_module(release)
+
+
+# ---------------------------------------------------------------------------
+# parse_semver
+# ---------------------------------------------------------------------------
+
+
+def test_parse_semver_accepts_strict_major_minor_patch():
+    assert release.parse_semver('1.35.0') == (1, 35, 0)
+    assert release.parse_semver('0.0.1') == (0, 0, 1)
+    assert release.parse_semver('10.20.30') == (10, 20, 30)
+
+
+def test_parse_semver_rejects_v_prefix(capsys):
+    with pytest.raises(SystemExit):
+        release.parse_semver('v1.35.0')
+    err = capsys.readouterr().err
+    assert 'MAJOR.MINOR.PATCH' in err
+
+
+def test_parse_semver_rejects_prerelease(capsys):
+    with pytest.raises(SystemExit):
+        release.parse_semver('1.35.0-rc1')
+
+
+def test_parse_semver_rejects_garbage(capsys):
+    with pytest.raises(SystemExit):
+        release.parse_semver('not-a-version')
+
+
+def test_parse_semver_rejects_two_segments(capsys):
+    with pytest.raises(SystemExit):
+        release.parse_semver('1.35')
+
+
+# ---------------------------------------------------------------------------
+# version.py read/write
+# ---------------------------------------------------------------------------
+
+
+def test_read_version_file_single_quoted():
+    src = "__version__ = '1.34.0'\n"
+    assert release.read_version_file(src) == '1.34.0'
+
+
+def test_read_version_file_double_quoted():
+    src = '__version__ = "2.0.0"\n'
+    assert release.read_version_file(src) == '2.0.0'
+
+
+def test_read_version_file_with_other_lines():
+    src = '"""docstring."""\n\nfrom __future__ import annotations\n\n__version__ = \'1.34.0\'\n'
+    assert release.read_version_file(src) == '1.34.0'
+
+
+def test_read_version_file_raises_when_missing():
+    with pytest.raises(ValueError):
+        release.read_version_file('no version here\n')
+
+
+def test_write_version_file_replaces_value_only():
+    src = "__version__ = '1.34.0'\n"
+    out = release.write_version_file(src, '1.35.0')
+    assert out == "__version__ = '1.35.0'\n"
+
+
+def test_write_version_file_preserves_double_quotes():
+    src = '__version__ = "1.34.0"\n'
+    out = release.write_version_file(src, '1.35.0')
+    assert out == '__version__ = "1.35.0"\n'
+
+
+def test_write_version_file_replaces_exactly_once():
+    """If someone added a stray '__version__' literal in a comment, we must
+    not rewrite it. Only the first canonical assignment changes.
+    """
+    src = (
+        '"""Module doc mentions __version__ in passing."""\n'
+        "__version__ = '1.34.0'\n"
+        '# trailing comment about __version__ should not be touched\n'
+    )
+    out = release.write_version_file(src, '1.35.0')
+    assert "__version__ = '1.35.0'" in out
+    # The comment line is untouched.
+    assert '# trailing comment about __version__ should not be touched' in out
+
+
+# ---------------------------------------------------------------------------
+# CHANGELOG section extraction
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_CHANGELOG = """# Changelog
+
+Header text.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- Thing A
+- Thing B
+
+### Fixed
+
+- Bug C
+
+---
+
+## [1.34.0] — 2026-04-30
+
+### Fixed (BREAKING)
+
+- SVG XSS hardening.
+
+---
+
+## [1.33.0] — 2026-04-25
+
+### Added
+
+- Session revocation channel.
+"""
+
+
+def test_extract_unreleased_section_returns_body_and_indices():
+    body, start, end = release.extract_section(SAMPLE_CHANGELOG, '## [Unreleased]')
+    assert '### Added' in body
+    assert '- Thing A' in body
+    assert '### Fixed' in body
+    assert '- Bug C' in body
+    # body must not include the next section's header
+    assert '## [1.34.0]' not in body
+    # start indexes the [Unreleased] header line itself
+    lines = SAMPLE_CHANGELOG.splitlines(keepends=True)
+    assert lines[start].rstrip() == '## [Unreleased]'
+    # end indexes the next ## header
+    assert lines[end].startswith('## [1.34.0]')
+
+
+def test_extract_section_raises_when_header_missing():
+    with pytest.raises(ValueError, match='section not found'):
+        release.extract_section(SAMPLE_CHANGELOG, '## [9.9.9]')
+
+
+def test_extract_section_strips_trailing_horizontal_rule():
+    body, _, _ = release.extract_section(SAMPLE_CHANGELOG, '## [1.34.0] — 2026-04-30')
+    # The body must NOT include the trailing `---` separator.
+    assert not body.rstrip().endswith('---')
+    assert '- SVG XSS hardening.' in body
+
+
+def test_is_unreleased_empty_true_for_placeholder_only():
+    body = release.UNRELEASED_PLACEHOLDER
+    assert release.is_unreleased_empty(body) is True
+
+
+def test_is_unreleased_empty_false_for_content():
+    assert release.is_unreleased_empty('### Added\n- something\n') is False
+
+
+def test_is_unreleased_empty_handles_surrounding_whitespace():
+    body = f'\n\n{release.UNRELEASED_PLACEHOLDER}\n\n'
+    assert release.is_unreleased_empty(body) is True
+
+
+# ---------------------------------------------------------------------------
+# transform_changelog — the heart of the release flow
+# ---------------------------------------------------------------------------
+
+
+def test_transform_changelog_renames_unreleased_with_date():
+    new_text, body = release.transform_changelog(SAMPLE_CHANGELOG, '1.35.0', '2026-06-01')
+    assert '## [1.35.0] — 2026-06-01' in new_text
+    # The original [Unreleased] header should no longer be sitting where
+    # the version 1.35.0 header now is, but a NEW fresh one must exist.
+    assert '## [Unreleased]' in new_text  # the fresh one we inserted
+    # The fresh Unreleased must come BEFORE the renamed 1.35.0
+    fresh_idx = new_text.index('## [Unreleased]')
+    released_idx = new_text.index('## [1.35.0]')
+    assert fresh_idx < released_idx, 'fresh [Unreleased] must precede the renamed section'
+
+
+def test_transform_changelog_fresh_unreleased_contains_placeholder():
+    new_text, _ = release.transform_changelog(SAMPLE_CHANGELOG, '1.35.0', '2026-06-01')
+    assert release.UNRELEASED_PLACEHOLDER in new_text
+
+
+def test_transform_changelog_preserves_older_sections():
+    new_text, _ = release.transform_changelog(SAMPLE_CHANGELOG, '1.35.0', '2026-06-01')
+    assert '## [1.34.0] — 2026-04-30' in new_text
+    assert '## [1.33.0] — 2026-04-25' in new_text
+
+
+def test_transform_changelog_returned_body_matches_renamed_section():
+    new_text, body = release.transform_changelog(SAMPLE_CHANGELOG, '1.35.0', '2026-06-01')
+    # The returned body is the content under the renamed [1.35.0] section,
+    # which is the same content that was under [Unreleased] in the input.
+    assert '### Added' in body
+    assert '- Thing A' in body
+    assert '- Bug C' in body
+    # The returned body must be a substring of the new CHANGELOG.
+    assert body.strip() in new_text
+
+
+def test_transform_changelog_refuses_empty_unreleased():
+    empty_input = SAMPLE_CHANGELOG.replace(
+        '### Added\n\n- Thing A\n- Thing B\n\n### Fixed\n\n- Bug C\n',
+        release.UNRELEASED_PLACEHOLDER + '\n',
+    )
+    with pytest.raises(ValueError, match='empty'):
+        release.transform_changelog(empty_input, '1.35.0', '2026-06-01')
+
+
+# ---------------------------------------------------------------------------
+# extract_release_body — what the CI workflow consumes
+# ---------------------------------------------------------------------------
+
+
+def test_extract_release_body_returns_section_content_after_release_cut():
+    """End-to-end: cut a release, then read the released body back. This
+    is exactly the path .github/workflows/release.yml runs against the
+    tag.
+    """
+    new_text, _ = release.transform_changelog(SAMPLE_CHANGELOG, '1.35.0', '2026-06-01')
+    body = release.extract_release_body(new_text, '1.35.0')
+    assert '### Added' in body
+    assert '- Thing A' in body
+    assert '- Bug C' in body
+    # Must not include the next older section's header.
+    assert '## [1.34.0]' not in body
+
+
+def test_extract_release_body_works_on_pre_existing_section():
+    """The function also has to work on sections that were already on
+    disk before the release script existed (any historical release).
+    """
+    body = release.extract_release_body(SAMPLE_CHANGELOG, '1.34.0')
+    assert '- SVG XSS hardening.' in body
+    assert '## [1.33.0]' not in body
+
+
+def test_extract_release_body_raises_for_unknown_version():
+    with pytest.raises(ValueError, match='not found'):
+        release.extract_release_body(SAMPLE_CHANGELOG, '9.9.9')


### PR DESCRIPTION
## Summary

- Adds a Semgrep workflow that runs on push + PR to main, complementing ruff (which already covers flake8-bandit via `S` codes) with cross-line pattern analysis.
- Enables three curated public rulesets (`p/python`, `p/security-audit`, `p/owasp-top-ten`) gated at `--severity ERROR` so WARNs are visible without breaking CI.
- Ships three Nori-specific custom rules that mechanise bug classes already discovered in prior audits — TOCTOU on cache, unguarded JWT/OAuth claim subscript, and CWD-relative `Path()` in the CLI subprocess scripts.
- Documents conventions, the `# nosem` justification protocol, and the roadmap for iterations 2–4 in `.semgrep/README.md`.

## Custom rules

| Rule | Severity | Scope | Bug class |
|------|----------|-------|-----------|
| `nori-toctou-cache-read-modify-write` | WARNING | repo-wide (except `core/cache.py`, tests) | CWE-367, the same class that Round 4 caught in login_guard, throttle_backends, and queue_worker |
| `nori-jwt-payload-required-claim` | ERROR | `core/auth/` | Unguarded `payload['jti'\|'sub'\|'iss'\|'aud'\|'nbf']` — KeyError DoS path per CLAUDE.md §6 |
| `nori-cli-cwd-relative-path` | ERROR | `core/cli.py` | Forward-looking guardrail for the path-resolution class in CLAUDE.md §7 |

## Test plan

- [x] Full repo scan with the three custom rules — 0 findings, 0 false positives
- [x] Synthetic positive trigger file — 3 findings (one per rule)
- [x] Synthetic negative trigger file (cache_incr, payload assignment, guarded read, `Path(__file__)`) — 0 findings
- [ ] CI: Semgrep workflow passes on this PR (this is what we are watching here)
- [ ] CI: existing workflows (lint, typecheck, tests, audit, secrets, sbom, docstrings) remain green — no regressions from adding the new workflow