### PR TITLE
feat!: signed double-submit CSRF cookie (v2.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ firebase-debug.log
 .gemini/
 CLAUDE.md
 .atl/
+openspec/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ When adding a new feature or module, follow these steps IN ORDER:
 3. **Migrate**: `python3 nori.py migrate:make desc` -> `python3 nori.py migrate:upgrade`.
 4. **Controller**: Create class in `modules/name.py`. Use `@inject()` and `validate()`.
 5. **Routes**: Define explicit `Route` or `Mount` in `routes.py` with a unique `name`.
-6. **Templates**: Create Jinja2 views. Use `{{ csrf_field(request.session)|safe }}` for POST forms.
+6. **Templates**: Create Jinja2 views. Use `{{ csrf_field(request)|safe }}` for POST forms.
 7. **Verify**: Run `pytest tests/` and ensure the new logic is covered.
 
 ---
@@ -89,6 +89,7 @@ These are quick reference reminders. The full catalog of bug classes (with CWE l
 - **Optional spec fields**: `payload.get('jti')`, never `payload['jti']`. See [INV-007](./INVARIANTS.md#inv-007-jwtoauth-optional-claims-must-be-accessed-defensively).
 - **Queue payloads**: `func_path` must pass `QUEUE_ALLOWED_MODULES` allow-list. See [INV-003](./INVARIANTS.md#inv-003-queue-worker-func_path-must-pass-allow-list-check-rce-defense).
 - **Session revocation**: All session-aware decorators (`login_required`, `require_role`, `require_any_role`, `require_permission`) check `session_version` against the live counter. See [INV-016](./INVARIANTS.md#inv-016-session-revocation-must-work-end-to-end-active-user-gate--version-counter).
+- **CSRF cookie**: Must be a signed structure `{nonce}.{sig}` (HMAC-SHA256). Bare-nonce double-submit is rejected. `cache_response` must never cache `Set-Cookie`. See [INV-030](./INVARIANTS.md#inv-030-csrf-cookie-must-be-a-signed-structure-set-cookie-must-never-be-cached).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,42 @@ _Nothing accumulated yet — add entries here as they ship to `main` so the next
 
 ---
 
+## [2.0.0] — (pending release)
+
+This release replaces the session-bound CSRF synchronizer token with an OWASP signed double-submit cookie, closes the cached-form 403 regression (issue #29), and aligns the form body cap with documented behavior.
+
+### Breaking
+
+- **`csrf_field` and `csrf_token` signatures changed**: both helpers now accept a Starlette `Request` object instead of a session dict. Find-and-replace in templates:
+  `csrf_field(request.session)` → `csrf_field(request)`
+  `csrf_token(request.session)` → `csrf_token(request)`
+  See [docs/upgrade-2.0.md](docs/upgrade-2.0.md) for the one-line migration command.
+- **Session-bound CSRF removed**: `session['_csrf_token']` is no longer set or read. Existing session entries expire naturally; no cleanup needed.
+
+### Added
+
+- **Signed double-submit cookie CSRF** (`core/auth/csrf.py`): cookie value = `{nonce}.{sig}` (HMAC-SHA256 over `SECRET_KEY`). Validation requires both (1) cookie integrity check and (2) double-submit match. Bare-nonce cookies are rejected (writer-attacker defense). Per-visitor cookie, never cached.
+- **BREACH masking**: `csrf_field` applies a per-render XOR mask over the cookie value. The server unmasks before comparing. Both masked (server-rendered) and raw (shim/header) submissions are accepted.
+- **JS shim** (`rootsystem/static/js/csrf.js`): before every form submit and fetch/XHR, reads the visitor's own CSRF cookie and writes it into `_csrf_token` / `X-CSRF-Token`. Fixes cached-form pages without client-side crypto.
+- **`base.html` shim include**: the starter layout includes `csrf.js` automatically.
+- **Six `CSRF_COOKIE_*` settings** with safe defaults via `config.get` (INV-029): `CSRF_COOKIE_NAME`, `CSRF_COOKIE_SECURE`, `CSRF_COOKIE_SAMESITE`, `CSRF_COOKIE_HTTPONLY`, `CSRF_COOKIE_PATH`, `CSRF_COOKIE_MAX_AGE`.
+- **`csrf_cookie_name()` Jinja global**: renders `window.NORI_CSRF_COOKIE_NAME` into the page so the shim tracks `__Host-` name changes without editing `csrf.js`.
+- **`INV-030`** in `INVARIANTS.md`: new invariant — CSRF cookie must be a signed structure; `cache_response` must never cache `Set-Cookie`. Includes L3 regression tests.
+- **v2.0.0 upgrade guide** at `docs/upgrade-2.0.md`.
+
+### Fixed
+
+- **Form body cap** aligned to **10 MB** (was 1 MiB in code; docs said 10 MB). INV-015 instance closed.
+- **Non-ASCII unmask DoS guard**: `_validate_submission` encodes candidate and cookie to bytes before `compare_digest`, preventing a `TypeError` crash on attacker-crafted masked tokens.
+- **`INV-004` fix recipe updated** in `INVARIANTS.md`: body cap default changed from 1 MiB to 10 MB; signed-cookie context added.
+- **`INV-016` cross-reference added**: "Related" line now points to INV-030 (CSRF ⟂ auth boundary).
+
+### Tests
+
+1062 passing (versus pre-change baseline). 40+ new tests covering the full signed double-submit suite: cookie issuance, HMAC validation, BREACH masking, dual-accept (raw + masked), cached-page shim simulation, writer-attacker defense, `cache_response` Set-Cookie regression pin.
+
+---
+
 ## [1.35.0] — 2026-05-26
 
 This release closes the 2026-05-25 audit cycle and ships the bug-class catalogue + release automation that make future audits converge instead of rediscover. No breaking changes; every addition is opt-in or transparent.

--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -188,18 +188,19 @@ Listed in order of historical discovery (oldest first). IDs are stable.
 - **Status**: Active
 - **Severity (max instance)**: HIGH
 - **Bug class**: A condition in the CSRF middleware intended as convenience becomes a bypass — either a Content-Type exemption that browsers can satisfy cross-origin, or body buffering that creates a DoS amplifier.
-- **Fix recipe**: (a) **No content-type exemptions** for browser-readable methods. JSON clients must send `X-CSRF-Token` header. (b) **Check the header before reading the body** so streaming and multipart uploads stay streamed. (c) Refuse `multipart/form-data` without the header (do NOT buffer to extract token). (d) Cap urlencoded body buffering at `CSRF_FORM_MAX_BODY_SIZE` (default 1 MiB).
+- **Fix recipe**: (a) **No content-type exemptions** for browser-readable methods. JSON clients must send `X-CSRF-Token` header. (b) **Check the header before reading the body** so streaming and multipart uploads stay streamed. (c) Refuse `multipart/form-data` without the header (do NOT buffer to extract token). (d) Cap urlencoded body buffering at `CSRF_FORM_MAX_BODY_SIZE` (default **10 MB**). The CSRF implementation is now a stateless **signed double-submit cookie** (v2.0.0) — request-shape rules (a)–(d) remain unchanged; see INV-030 for the cookie-signing invariant.
 - **Detector maturity**:
   - L1: yes (manual review on `core/auth/csrf.py` changes)
-  - L2: pre-merge checklist for csrf.py — verify header-first, multipart refusal, body cap intact
+  - L2: pre-merge checklist for csrf.py — verify header-first, multipart refusal, body cap intact, cookie = `{nonce}.{sig}` (not bare nonce)
   - L3: behavior tests + docs↔code mismatch caught by INV-015 manual checklist
 - **Coverage by area**:
   - `core/auth/csrf.py`: full behavior coverage
 - **Instances**:
   - v1.17.0: removed `application/json` short-circuit
   - v1.22.0: multipart-without-header refused, body cap configurable
-- **Regression tests**: `test_multipart_without_header_is_refused`, `test_multipart_with_header_passes_without_buffering`, `test_form_body_cap_is_configurable`
-- **Related**: INV-015 (docs↔code coherence — body cap previously documented as 10 MB while code is 1 MiB)
+  - v2.0.0: session-bound CSRF replaced by signed double-submit cookie; body cap aligned to 10 MB (INV-015 instance closed)
+- **Regression tests**: `test_multipart_without_header_is_refused`, `test_multipart_with_header_passes_without_buffering`, `test_form_body_cap_is_configurable`, `test_form_body_cap_default_is_10mb`
+- **Related**: INV-015 (docs↔code coherence — body cap aligned to 10 MB in v2.0.0), INV-030 (signed double-submit cookie — the CSRF wire-format invariant)
 
 ---
 
@@ -483,7 +484,7 @@ Listed in order of historical discovery (oldest first). IDs are stable.
   - v1.33.0: per-user `session_version` counter
   - v1.33.1: explicit TTL on `session_guard` cache writes
 - **Regression tests**: `test_load_permissions_refuses_inactive_user`, `test_login_required_denies_when_session_version_revoked`, `test_require_role_denies_when_session_version_revoked`, `test_require_any_role_denies_when_session_version_revoked`, `test_require_permission_denies_when_session_revoked`, `test_cache_writes_respect_configurable_ttl`, plus 18 more in `test_session_guard.py`
-- **Related**: INV-007 (JWT revocation — same family of "auth must support fast invalidation")
+- **Related**: INV-007 (JWT revocation — same family of "auth must support fast invalidation"), INV-030 (CSRF cookie statelessness — the deliberate CSRF ⟂ auth boundary)
 
 ---
 
@@ -786,6 +787,34 @@ Listed in order of historical discovery (oldest first). IDs are stable.
 
 ---
 
+### INV-030: CSRF cookie must be a signed structure; Set-Cookie must never be cached
+
+- **CWE**: CWE-352 (CSRF)
+- **First seen**: v2.0.0
+- **Status**: Active
+- **Severity (max instance)**: HIGH
+- **Bug class (two coupled forms)**:
+  1. *Unsigned double-submit*: a scheme where the submitted token equals (or is trivially derivable from) the cookie value with **no internal signature**. An attacker who can WRITE a cookie on the target domain (subdomain XSS, MITM on a sibling host, cookie-tossing) sets cookie=X and field=X and bypasses CSRF entirely.
+  2. *Cached `Set-Cookie`*: caching the CSRF `Set-Cookie` header (e.g. via `cache_response`) shares one cookie value across every visitor for the cache TTL. An attacker harvests the shared value and a valid (replayable, even if masked) token from the cached page and forges a cross-site request that every co-visitor's auto-sent shared cookie matches → site-wide CSRF bypass for the full TTL.
+- **Fix recipe**:
+  - The cookie value MUST be the **signed structure** `{nonce}.{sig}` where `nonce = secrets.token_hex(32)` and `sig = HMAC-SHA256(SECRET_KEY, nonce)` hexdigest. The submitted value is the cookie value, accepted **raw or BREACH-masked** (server unmasks then compares). Validation is two constant-time checks: (1) recompute the sig over the cookie's nonce and `compare_digest` → reject forged cookies; (2) `compare_digest` the (unmasked) submission to the cookie value. A bare-nonce (unsigned) cookie MUST be rejected at check (1). `SECRET_KEY` is read via `core.conf.config`.
+  - **`Set-Cookie` MUST be per visitor and MUST NEVER be cached.** `cache_response` MUST cache only body/status/media_type — it does today (`core/cache.py` caches `{'body_b64', 'status_code', 'media_type'}` only). This property is **load-bearing** for CSRF correctness; protect it with a regression test (`test_cache_response_never_emits_cached_set_cookie`). The `CsrfMiddleware` send-wrapper sets the CSRF `Set-Cookie` on the **live** response only, never via the cache value.
+- **Boundary (CSRF ⟂ auth)**: The CSRF cookie is stateless and cannot be server-invalidated. A user with a revoked session (INV-016) still holds a valid CSRF cookie — this is acceptable because the auth decorators (`login_required`, `require_role`, `require_any_role`, `require_permission`) reject the request at the authorization layer before any handler runs. CSRF proves origin, not identity. Do NOT file "CSRF cookie outlives session revocation" as a finding.
+- **Boundary (CSRF ⟂ XSS)**: An XSS-capable attacker reads the live cookie and the DOM, defeating **any** CSRF wire format. This is out of scope for CSRF; mitigate XSS via CSP and escaping. Do NOT use read-leak/XSS scenarios to argue a CSRF token shape.
+- **Detector maturity**:
+  - L1: yes (manual review on `core/auth/csrf.py` cookie structure + `core/cache.py` header caching)
+  - L2: pre-merge checklist — cookie = `{nonce}.{sig}`, sig verified before match, unsigned cookie rejected, masking present, `cache_response` caches no headers
+  - L3: behavior tests (`test_validate_rejects_signature_invalid_cookie`, `test_validate_rejects_unsigned_naive_double_submit`, `test_masked_token_differs_per_render`, `test_cache_response_never_emits_cached_set_cookie`, `test_forged_cookie_writer_attack_fails`)
+- **Coverage by area**:
+  - `core/auth/csrf.py`: full behavior coverage (cookie structure + dual-accept validation)
+  - `core/cache.py`: regression pin that `Set-Cookie` is never cached
+- **Instances**:
+  - v2.0.0: signed double-submit cookie replaces session-bound synchronizer token; `Set-Cookie` confirmed uncached and pinned with regression test
+- **Regression tests**: `test_validate_accepts_raw_cookie_value`, `test_validate_accepts_masked_cookie_value`, `test_validate_rejects_signature_invalid_cookie`, `test_validate_rejects_unsigned_naive_double_submit`, `test_cache_response_never_emits_cached_set_cookie`, `test_forged_cookie_writer_attack_fails`
+- **Related**: INV-004 (CSRF request-shape rejection), INV-016 (session revocation — the auth-layer counterpart to this cookie's statelessness), INV-029 (CSRF_COOKIE_* defaults via config.get)
+
+---
+
 ## Roadmap — L1/L2 entries to graduate to L3
 
 These are the highest-leverage Semgrep/test mechanizations remaining. Sorted by impact × frequency.
@@ -816,3 +845,4 @@ When you complete an audit pass, append here:
 | 2026-05-25 | full sweep (code + docs + tests) | none (all 4 Criticals matched existing INVs: INV-004 docs side, INV-026 shell, INV-016 require_role/any_role test gap, INV-007 OAuth subscript propagation) | INV-015 (4 doc mismatches), INV-027 (cli.py:20 `_APP_DIR`) | Shipped Semgrep CI (PR #28) — 5 custom rules across INV-001, INV-002, INV-007, INV-021, INV-027 |
 | 2026-05-26 | iter 3 graduation: INV-002 + INV-001 to L3 full | none | none | Added 3 new Semgrep rules: `nori-sync-time-sleep-in-async`, `nori-sync-requests-import-in-services`, `nori-sync-subprocess-in-async`. `services/*` swept manually for INV-001 partner calls — zero usages. Full repo scan: 8 rules × 71 files = 0 findings. Convergence metric: 0 new classes, 0 regressions — pure mechanization work. |
 | 2026-05-26 | git/release/docs flow review | none | INV-015 (4 new instances: mike fiction in `mkdocs.yml`, VPS+rsync fiction in `docs/deployment.md`, 2 dead anchors in code_quality.md + dependencies.md) | Cleanup PR: pinned `mkdocs-material>=9.7.6` in deploy workflow, added `--strict` to `mkdocs build`, removed unused `extra.version: mike` stanza, rewrote `docs/deployment.md` Documentation site section to describe the actual Firebase + GH Actions pipeline, fixed both dead anchors, added `[Unreleased]` section to CHANGELOG. Convergence metric: 0 new classes, 4 INV-015 regressions caught manually — confirms that L3 for INV-015 remains infeasible (would have needed a docs-vs-real-infra check that no static tool can do). |
+| 2026-06-11 | csrf-double-submit v2.0.0 docs slice | INV-030 (signed cookie + Set-Cookie never cached) | INV-004 (body cap updated to 10 MB, signed-cookie context added), INV-016 (added cross-reference to INV-030 per CSRF ⟂ auth boundary) | CSRF rewrite: stateless signed double-submit cookie replaces session-bound synchronizer token. INV-004 fix recipe updated (10 MB body cap, signed double-submit context). INV-016 "Related" gains INV-030 back-reference. New INV-030 covers both unsigned-cookie and cached-Set-Cookie bypass forms with L3 regression tests. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,8 +120,8 @@ Response ←──┘
 | **RequestIdMiddleware** | `core.http.request_id` | Generates a UUID per request (or propagates incoming `X-Request-ID`). Stored in `request.state.request_id`. Added to every response as `X-Request-ID` header. Enables end-to-end tracing across logs and services. |
 | **SecurityHeadersMiddleware** | `core.http.security_headers` | Injects security headers on every response: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`, `Strict-Transport-Security` (HSTS, 1 year). Optional CSP if configured. |
 | **CORSMiddleware** | `starlette.middleware.cors` | Only added if `CORS_ORIGINS` is set in `.env`. Handles `OPTIONS` preflight and adds `Access-Control-*` headers. |
-| **SessionMiddleware** | `starlette.middleware.sessions` | Creates and validates signed session cookies using `SECRET_KEY`. Populates `request.session` as a dict-like object. Required by CSRF, auth decorators, and flash messages. |
-| **CsrfMiddleware** | `core.auth.csrf` | Validates CSRF tokens on state-changing methods (POST, PUT, DELETE, PATCH). Skips safe methods (GET, HEAD, OPTIONS). Checks `X-CSRF-Token` header first, then `_csrf_token` form field (form bodies only — JSON clients must send the header). Auto-generates token if missing. Returns 403 on mismatch, 413 on oversized body (DoS protection, 10 MB limit). |
+| **SessionMiddleware** | `starlette.middleware.sessions` | Creates and validates signed session cookies using `SECRET_KEY`. Populates `request.session` as a dict-like object. Required by auth decorators, flash messages, and OAuth state (CSRF is stateless as of v2.0.0 and no longer depends on it). |
+| **CsrfMiddleware** | `core.auth.csrf` | Stateless signed double-submit cookie CSRF (v2.0.0). Issues a per-visitor `{nonce}.{sig}` cookie via a `send`-wrapper (never cached). Validates with two constant-time checks: (1) HMAC cookie integrity, (2) double-submit match (raw or BREACH-masked). Checks `X-CSRF-Token` header first (no body read); falls back to `_csrf_token` urlencoded field. JSON and multipart clients must use the header. Returns 403 on mismatch, 413 on body exceeding 10 MB cap. |
 
 ### Why This Order Matters
 
@@ -130,7 +130,7 @@ Middleware order matters. Request ID wraps everything because every log line nee
 - **Request ID first**: ensures every log message — including middleware errors — has a trace ID.
 - **Security headers early**: guarantees all responses get security headers, even on middleware failures.
 - **CORS before session**: preflight `OPTIONS` requests must be handled before session cookie processing.
-- **Session before CSRF**: CSRF middleware reads `scope['session']` to get/set the CSRF token, so the session must be populated first.
+- **Session before CSRF**: session is populated before CSRF runs, so auth decorators downstream can read session data after CSRF validation passes. (CSRF itself is now stateless and does not read the session.)
 - **CSRF last**: processes the request body after all other middleware can read from the request.
 
 ---

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -134,7 +134,7 @@ async def create(self, request: Request):
         return templates.TemplateResponse(request, 'product/form.html', {
             'errors': {}
         })
-        # csrf_field is a Jinja2 global — use {{ csrf_field(request.session)|safe }} in the template
+        # csrf_field is a Jinja2 global — use {{ csrf_field(request)|safe }} in the template
 
     # 2. If the user sends a POST, we process the logic here
     form = dict(await request.form())

--- a/docs/forms_validation.md
+++ b/docs/forms_validation.md
@@ -10,7 +10,7 @@ Every form that makes a `POST` request must include a CSRF token. Since `csrf_fi
 
 ```html
 <form method="POST">
-    {{ csrf_field(request.session)|safe }}
+    {{ csrf_field(request)|safe }}
 
     <label>User</label>
     <input type="text" name="usr">
@@ -19,7 +19,7 @@ Every form that makes a `POST` request must include a CSRF token. Since `csrf_fi
 </form>
 ```
 
-`csrf_field(request.session)` returns a `<input type="hidden" name="_csrf_token" value="...">` tag. The `|safe` filter is required to render the raw HTML.
+`csrf_field(request)` returns a `<input type="hidden" name="_csrf_token" value="...">` tag. The `|safe` filter is required to render the raw HTML.
 
 If the CSRF token is missing or invalid on a state-changing request (POST, PUT, DELETE, PATCH), the middleware returns `403 Forbidden`.
 
@@ -193,7 +193,7 @@ Inside Jinja2, since you have fed the template back with a dictionary `{field: [
 
 ```html
 <form method="POST">
-    {{ csrf_field(request.session)|safe }}
+    {{ csrf_field(request)|safe }}
 
     <input name="email" value="{{ usr_email|default('') }}" />
     {% if errors.email %}

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -70,7 +70,7 @@ Middleware order is not arbitrary. Each position is deliberate:
 - **RequestId first**: every log line — including middleware errors — gets a trace ID.
 - **SecurityHeaders early**: all responses get security headers, even on middleware failures.
 - **CORS before Session**: preflight `OPTIONS` requests must be handled before session cookie processing.
-- **Session before CSRF**: the CSRF middleware reads `scope['session']` to get/set the token, so the session must be populated first.
+- **Session before CSRF**: session is populated before CSRF runs, so auth decorators downstream can read session data after CSRF validation passes. (CSRF itself is now stateless and does not read the session.)
 - **CSRF last**: processes the request body after all other middleware have had their turn.
 
 ---
@@ -169,7 +169,7 @@ Creates and validates signed session cookies using `SECRET_KEY`. Populates `requ
 | `secret_key` | `str` | `settings.SECRET_KEY` | Key for signing session cookies |
 | `https_only` | `bool` | `not settings.DEBUG` | Only send cookie over HTTPS |
 
-Sessions are required by CSRF protection, authentication decorators (`@login_required`, `@role_required`), and flash messages. In production (`DEBUG=False`), the cookie is marked `Secure` so it is never sent over plain HTTP.
+Sessions are required by authentication decorators (`@login_required`, `@role_required`), flash messages, and OAuth state. CSRF is stateless as of v2.0.0 and no longer depends on the session. In production (`DEBUG=False`), the cookie is marked `Secure` so it is never sent over plain HTTP.
 
 ---
 
@@ -177,7 +177,7 @@ Sessions are required by CSRF protection, authentication decorators (`@login_req
 
 **Module**: `core.auth.csrf`
 
-Validates CSRF tokens on all state-changing HTTP methods (POST, PUT, DELETE, PATCH). Full details in [Security](security.md#csrf-protection).
+Validates CSRF tokens on all state-changing HTTP methods (POST, PUT, DELETE, PATCH) using an OWASP **signed double-submit cookie** (v2.0.0). The middleware is stateless — it does not read or write the session for CSRF purposes. Full details in [Security](security.md#csrf-protection).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -185,11 +185,14 @@ Validates CSRF tokens on all state-changing HTTP methods (POST, PUT, DELETE, PAT
 
 **Key behaviors**:
 
-- **Token generation**: auto-generates a token into `session['_csrf_token']` on the first request.
-- **Token lookup**: checks `X-CSRF-Token` header first, then `_csrf_token` form field (URL-encoded and multipart). JSON requests must use the header — body parsing is form-only.
+- **Cookie issuance**: on every request without a valid CSRF cookie, a fresh `{nonce}.{sig}` cookie is issued via a `send`-wrapper that appends `Set-Cookie` to the live response. The cookie is **per visitor** and never cached (INV-030).
+- **Validation (two checks)**:
+  1. Cookie integrity — recompute `HMAC-SHA256(SECRET_KEY, nonce)` over the cookie's nonce and constant-time-compare to the cookie's `sig`. Forged cookies die here.
+  2. Double-submit match — constant-time-compare the (unmasked) submitted value to the full cookie value. Both raw (shim/header path) and BREACH-masked (server-rendered form field) submissions are accepted.
+- **Token submission paths**: `X-CSRF-Token` header is checked first (body not read); then `_csrf_token` in a urlencoded form body; JSON and multipart requests must use the header.
 - **Safe methods**: GET, HEAD, OPTIONS, TRACE are always exempt.
-- **Body size limit**: rejects bodies larger than 10 MB with 413 (DoS protection).
-- **Constant-time comparison**: uses `hmac.compare_digest` to prevent timing attacks.
+- **Body size limit**: urlencoded form bodies are buffered up to `CSRF_FORM_MAX_BODY_SIZE` (default **10 MB**); exceeded bodies return 413. Multipart bodies are never buffered — use `X-CSRF-Token` header for file-upload requests.
+- **Constant-time comparison**: both HMAC verification and double-submit match use `hmac.compare_digest`.
 
 **Exempt specific paths** (e.g., a webhook endpoint):
 
@@ -200,12 +203,14 @@ Middleware(CsrfMiddleware, exempt_paths={'/webhooks/stripe', '/webhooks/github'}
 **Template helpers** (registered as Jinja2 globals):
 
 ```html
-<!-- Full hidden input -->
-{{ csrf_field(request.session)|safe }}
+<!-- Full hidden input (BREACH-masked per render) -->
+{{ csrf_field(request)|safe }}
 
-<!-- Raw token for AJAX -->
-{{ csrf_token(request.session) }}
+<!-- Raw cookie value for AJAX X-CSRF-Token header -->
+{{ csrf_token(request) }}
 ```
+
+The JS shim (`static/js/csrf.js`, included by `base.html`) automatically sets `X-CSRF-Token` on every fetch/XHR and overwrites stale `_csrf_token` fields on cached pages before submit. Sites not extending `base.html` must include the shim on any page served from `cache_response` that submits forms.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,41 +79,73 @@ Then route it: `Route('/csp-violations', csp.report, methods=['POST'])`. Make su
 
 ## CSRF Protection
 
-`CsrfMiddleware` validates CSRF tokens on all state-changing HTTP methods (POST, PUT, DELETE, PATCH).
+`CsrfMiddleware` validates CSRF tokens on all state-changing HTTP methods (POST, PUT, DELETE, PATCH). Since v2.0.0, Nori uses an OWASP **signed double-submit cookie** — a stateless, cache-safe scheme that requires no session reads for CSRF purposes.
 
-### How it works
+### How it works (v2.0.0 — signed double-submit cookie)
 
-1. On the first request, the middleware auto-generates a CSRF token and stores it in `request.session['_csrf_token']`.
-2. On state-changing requests, it checks for the token in:
-   - `X-CSRF-Token` header (for AJAX/fetch requests)
-   - `_csrf_token` form field (for HTML forms)
-3. Comparison uses constant-time HMAC (`hmac.compare_digest`) to prevent timing attacks.
-4. Mismatch returns **403 Forbidden**.
-5. Oversized body (> 10 MB) returns **413 Request Entity Too Large** (DoS protection).
+**Cookie issuance.** On every request where the visitor does not yet have a valid CSRF cookie, the middleware generates a signed cookie value and issues it via a `send`-wrapper that appends a `Set-Cookie` header to the live response. The cookie is **per visitor** and **never cached** (caching it would be a site-wide CSRF bypass — see INV-030).
+
+The cookie value is a **signed structure** `{nonce}.{sig}`:
+- `nonce = secrets.token_hex(32)` — 64 hex characters, cryptographically random.
+- `sig = HMAC-SHA256(SECRET_KEY, nonce)` hexdigest — 64 hex characters.
+
+**Validation (two checks, both constant-time).** On state-changing requests:
+
+1. **Cookie integrity check**: split the cookie at the last `.`, recompute `HMAC(SECRET_KEY, nonce)`, and `compare_digest` against the cookie's `sig`. A forged cookie (written by an attacker who does not know `SECRET_KEY`) fails here — this is the defense against cookie-writer attackers.
+2. **Double-submit match**: compare the (unmasked) submitted token to the full cookie value. Both raw and BREACH-masked submissions are accepted — the middleware unmasks before comparing if the submitted value looks like a masked envelope.
+
+A forged or unsigned cookie is rejected at check (1), before check (2) runs.
+
+**BREACH masking.** `csrf_field(request)` applies a per-render XOR mask over the cookie value before emitting the hidden `_csrf_token` field. Each page render produces a different ciphertext for the same cookie value, preventing compression-oracle (BREACH) attacks when the response is gzip-compressed by a front proxy. The JS shim and the `X-CSRF-Token` header path always submit the raw (unmasked) cookie value.
+
+**JS shim.** `rootsystem/static/js/csrf.js` (included automatically via `base.html`) runs before every form submit and fetch/XHR request. It reads the visitor's own CSRF cookie from `document.cookie` and overwrites the `_csrf_token` hidden field with the raw cookie value, correcting any stale cached field from a previous visitor. This is what makes cached form pages work correctly — the shim supplies the **live** visitor's own cookie, which passes both validation checks. Pages that are never served from cache work without the shim (the server renders the correct masked value directly).
+
+**Body cap.** Urlencoded form bodies are buffered up to `CSRF_FORM_MAX_BODY_SIZE` (default **10 MB**). Bodies exceeding the cap return **413 Payload Too Large**. Multipart form data is never buffered — clients submitting file uploads must send the token via `X-CSRF-Token` header.
+
+### Cookie attributes
+
+All attributes are configurable via `settings.py` (read with `config.get` — INV-029):
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `CSRF_COOKIE_NAME` | `'csrftoken'` | Use `'__Host-csrftoken'` for single-host HTTPS (see below) |
+| `CSRF_COOKIE_SECURE` | `not DEBUG` | `True` in production; forced `True` for `__Host-` names |
+| `CSRF_COOKIE_SAMESITE` | `'Lax'` | `'Strict'` is opt-in for same-site-only forms |
+| `CSRF_COOKIE_HTTPONLY` | `False` | **Must stay `False`** — the JS shim reads `document.cookie` |
+| `CSRF_COOKIE_PATH` | `'/'` | Forced `'/'` for `__Host-` names |
+| `CSRF_COOKIE_MAX_AGE` | `None` | Session cookie by default; set to integer seconds if needed |
+
+**`__Host-` prefix recommendation.** For single-host HTTPS deployments, set `CSRF_COOKIE_NAME="__Host-csrftoken"`. The browser will enforce `Secure`, `Path=/`, and no `Domain` attribute on the cookie, closing the subdomain cookie-injection vector. Do not use `__Host-` on multi-subdomain deployments or plain HTTP — the browser will reject the cookie silently.
+
+### CSRF ⟂ session revocation (important boundary)
+
+The CSRF cookie is **stateless** and cannot be invalidated server-side. A user whose session has been revoked (INV-016) still holds a valid CSRF cookie. This is **by design and acceptable**: CSRF proves "did this request come from our origin?" while session revocation proves "is this user still authorized?". These are orthogonal concerns.
+
+Auth decorators (`@login_required`, `@require_role`, etc.) check `session_version` against the live counter and block the request **before any handler runs**, regardless of whether the CSRF token is valid. A revoked-session user is blocked at the authorization layer. Do not file "CSRF cookie outlives session revocation" as a finding — see INV-030 for the full rationale.
 
 ### Exempt from CSRF
 
 - **Safe methods**: GET, HEAD, OPTIONS, TRACE
-- **Custom paths**: Configurable exempt paths
+- **Custom paths**: configure `exempt_paths` on `CsrfMiddleware`
 
 ### JSON clients
 
-JSON requests are **not exempt**. The `Content-Type: application/json` header alone is not a safe CSRF defense — it relies on CORS being configured correctly, which is not a guarantee Nori can enforce. JSON clients (SPAs, fetch, axios) must send the token via the `X-CSRF-Token` header on every state-changing request.
+JSON requests are **not exempt**. JSON clients (SPAs, fetch, axios) must send the CSRF cookie value via the `X-CSRF-Token` header. The body is not parsed for JSON requests — the header is the only accepted channel.
 
-### Usage in Templates
+### Usage in templates
 
-`csrf_field` and `csrf_token` are registered as Jinja2 globals — you can call them directly in any template without passing them from the controller:
+`csrf_field` and `csrf_token` are registered as Jinja2 globals — call them directly in any template:
 
 ```html
 <form method="POST" action="/articles">
-    {{ csrf_field(request.session)|safe }}
+    {{ csrf_field(request)|safe }}
     <input type="text" name="title" />
     <button type="submit">Create</button>
 </form>
 ```
 
-- `csrf_field(request.session)` returns a full `<input type="hidden" ...>` tag — use `|safe` to render the HTML.
-- `csrf_token(request.session)` returns the raw token string (useful for AJAX headers).
+- `csrf_field(request)` returns a full `<input type="hidden" name="_csrf_token" value="...">` tag (BREACH-masked). Use `|safe` to render the HTML.
+- `csrf_token(request)` returns the raw `{nonce}.{sig}` cookie value (for AJAX `X-CSRF-Token` headers).
 
 For AJAX requests:
 
@@ -121,12 +153,14 @@ For AJAX requests:
 fetch('/articles', {
     method: 'POST',
     headers: {
-        'X-CSRF-Token': '{{ csrf_token(request.session) }}',
+        'X-CSRF-Token': '{{ csrf_token(request) }}',
         'Content-Type': 'application/json',
     },
     body: JSON.stringify({ title: 'Hello' }),
 });
 ```
+
+The JS shim sets `X-CSRF-Token` automatically on every fetch/XHR request, so the template snippet above is only needed if you are building requests outside the shim's reach.
 
 ---
 
@@ -544,7 +578,7 @@ When building with Nori, ensure:
 - [ ] `DEBUG=false` in production (disables debug error pages)
 - [ ] `CORS_ORIGINS` only lists trusted domains (or is empty for same-site)
 - [ ] State-changing actions use POST/PUT/DELETE, never GET
-- [ ] All forms include `{{ csrf_field(request.session) }}`
+- [ ] All forms include `{{ csrf_field(request)|safe }}`
 - [ ] Models with sensitive fields define `protected_fields`
 - [ ] File upload `allowed_types` is restrictive (don't allow `*`)
 - [ ] Rate limiting is applied to authentication and expensive endpoints

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -98,13 +98,13 @@ Every `POST` form **must** include a CSRF token. `csrf_field` is a Jinja2 global
 
 ```html
 <form method="POST" action="/articles">
-    {{ csrf_field(request.session)|safe }}
+    {{ csrf_field(request)|safe }}
     <input type="text" name="title" />
     <button type="submit">Create</button>
 </form>
 ```
 
-For AJAX requests, use the raw token via `csrf_token(request.session)` in the `X-CSRF-Token` header. See [Forms & Validation](forms_validation.md) for full details.
+For AJAX requests, use the raw token via `csrf_token(request)` in the `X-CSRF-Token` header. See [Forms & Validation](forms_validation.md) for full details.
 
 ## Flash Messages
 

--- a/docs/upgrade-2.0.md
+++ b/docs/upgrade-2.0.md
@@ -1,0 +1,105 @@
+# Upgrading to Nori v2.0.0
+
+Nori v2.0.0 replaces the session-bound CSRF synchronizer token with an OWASP **signed double-submit cookie**. The change is stateless, requires no database migration, and only needs mechanical template updates plus an optional settings block.
+
+---
+
+## What changed (breaking)
+
+| Area | v1.x behavior | v2.0.0 behavior |
+|------|---------------|-----------------|
+| CSRF token source | `session['_csrf_token']` set on GET | Per-visitor signed cookie `{nonce}.{sig}` issued via response `Set-Cookie` |
+| Template helper signature | `csrf_field(request.session)` | `csrf_field(request)` |
+| Token helper signature | `csrf_token(request.session)` | `csrf_token(request)` |
+| Form body cap default | 1 MiB | **10 MB** |
+| Cached form pages | Broke when served to a second visitor | Fixed — JS shim supplies the visitor's own cookie value |
+
+---
+
+## Quick path
+
+1. **Bump** to Nori v2.0.0.
+2. **Find-and-replace** in your templates (see commands below).
+3. **Include the JS shim** on any page served from `cache_response` that submits forms (automatic if you extend the starter `base.html`).
+4. **Review settings** — all `CSRF_COOKIE_*` settings have safe defaults; override only if needed.
+5. **Verify** — submit a form on a cached page from two different browsers; both must succeed without a 403.
+
+---
+
+## Step 2 — Template find-and-replace
+
+Replace all `csrf_field(request.session)` and `csrf_token(request.session)` calls with the new `request`-based signature:
+
+```bash
+# Find affected templates
+rg -l 'csrf_field\(request\.session\)|csrf_token\(request\.session\)' templates/
+
+# Replace in one pass (requires sd — install with: cargo install sd)
+rg -l 'csrf_field\(request\.session\)|csrf_token\(request\.session\)' templates/ \
+  | xargs sd 'csrf_(field|token)\(request\.session\)' 'csrf_$1(request)'
+```
+
+The replacement is purely mechanical — no logic change, only the argument type changes from `session dict` to `request object`.
+
+---
+
+## Step 3 — JS shim
+
+The JS shim (`static/js/csrf.js`) reads the visitor's own CSRF cookie and writes it into the hidden `_csrf_token` field before every form submit. This is what makes cached form pages work correctly.
+
+**If you extend the starter `base.html`**, the shim is already included — no action needed.
+
+**If you use a custom base layout**, add this snippet before `</body>` on any page that (a) is served from `cache_response` AND (b) submits a POST form:
+
+```html
+<!-- Nori CSRF shim: before submit, copies this visitor's own CSRF cookie value into the
+     hidden _csrf_token field and sets X-CSRF-Token on fetch/XHR, so forms on cached pages
+     submit successfully even though the cached HTML carries a stranger's stale token. -->
+<script src="/static/js/csrf.js" defer></script>
+```
+
+Pages that are never cached work without the shim (the server renders the correct masked value directly from the visitor's cookie).
+
+---
+
+## Step 4 — Settings (optional)
+
+All `CSRF_COOKIE_*` settings default safely. Override in `settings.py` only if needed:
+
+```python
+# settings.py — v2.0.0 CSRF cookie settings (all are optional; defaults shown)
+CSRF_COOKIE_NAME     = "csrftoken"        # or "__Host-csrftoken" for single-host HTTPS
+CSRF_COOKIE_SECURE   = not DEBUG          # True in production
+CSRF_COOKIE_SAMESITE = "Lax"             # "Strict" for same-site-only forms
+CSRF_COOKIE_HTTPONLY = False             # MUST stay False — the JS shim reads document.cookie
+CSRF_COOKIE_PATH     = "/"
+# CSRF_COOKIE_MAX_AGE = None            # session cookie by default; set to int seconds if needed
+```
+
+**`__Host-` prefix recommendation.** For single-host HTTPS deployments, set `CSRF_COOKIE_NAME = "__Host-csrftoken"`. This enforces `Secure`, `Path=/`, and no `Domain` at the browser level, closing the subdomain cookie-injection attack vector. Do not use `__Host-` on multi-subdomain deployments or plain HTTP — the browser will silently reject the cookie.
+
+**Persistent cache backend and cookie name changes.** If you change `CSRF_COOKIE_NAME` on a deployment using a **persistent Redis cache backend**, you must flush the cache after deploying. Cached pages embed `window.NORI_CSRF_COOKIE_NAME` (rendered by `base.html` from config). Until the cache is flushed, visitors served a stale cached page will look for the old cookie name — the shim will not find the new cookie and forms will 403.
+
+---
+
+## What you do NOT need to do
+
+- **No DB migration** — the change is stateless. There is no new table or column.
+- **No controller changes** — only templates and (optionally) settings.
+- **No manual session cleanup** — old `_csrf_token` keys in existing sessions are ignored by the new middleware and expire naturally with the session.
+
+---
+
+## Migration checklist
+
+- [ ] All `csrf_field(request.session)` / `csrf_token(request.session)` calls replaced with `csrf_field(request)` / `csrf_token(request)`.
+- [ ] CSRF shim included on all pages served from `cache_response` that submit forms (or `base.html` extended).
+- [ ] `CSRF_COOKIE_HTTPONLY` is `False` (or unset — default is `False`).
+- [ ] In production, `CSRF_COOKIE_SECURE` is `True` and the site is HTTPS.
+- [ ] A form on a `cache_response` page submits successfully from a second browser/visitor.
+
+---
+
+## Verification
+
+Submit a form on a page decorated with `@cache_response` from two different browsers (or two different incognito sessions). Both submissions must return 200, not 403. The first visit warms the cache; the second visit receives the cached page body but a fresh per-visitor `Set-Cookie` from the middleware's send-wrapper — the shim reads that cookie and writes it into the form field before submission.

--- a/rootsystem/application/core/auth/csrf.py
+++ b/rootsystem/application/core/auth/csrf.py
@@ -1,30 +1,79 @@
 """
-CSRF Middleware for Starlette.
-Validates tokens on state-changing requests (POST, PUT, DELETE, PATCH).
-Must be placed AFTER SessionMiddleware in the stack.
+CSRF Middleware for Starlette — signed double-submit cookie (v2.0.0).
+
+Replaces the session-bound synchronizer-token approach (v1.x) with an
+OWASP *Signed Double-Submit Cookie*. The middleware is now stateless:
+it no longer reads or writes the session for CSRF purposes.
+
+Wire format:
+    Cookie value = ``{nonce}.{sig}`` where:
+        nonce = secrets.token_hex(32)   (64 hex chars)
+        sig   = HMAC-SHA256(SECRET_KEY, nonce) hexdigest  (64 hex chars)
+    The two parts are joined by a literal ``.`` and split at the **last** ``.``.
+
+    Submitted token = the cookie value, accepted in two forms:
+        * **Raw**    — copied verbatim by the JS shim or X-CSRF-Token header clients.
+        * **Masked** — BREACH XOR envelope produced by ``csrf_field``; server
+          unmasks before comparing (per-render mask prevents compression oracles).
+
+Validation (two checks, both constant-time):
+    (1) Cookie integrity: recompute HMAC(SECRET_KEY, nonce) over the cookie's
+        nonce part; reject with 403 if the cookie's sig does not match.
+        This blocks cookie-writer attackers who cannot forge a valid HMAC
+        without SECRET_KEY.
+    (2) Double-submit match: unmask the submitted value if masked; reject with
+        403 if it does not equal the full cookie value.
 
 Body buffering trade-off:
-    To extract a CSRF token from a form body the middleware would have
-    to read the entire body — which defeats Starlette's streaming for
-    file uploads (a 100 MB upload becomes a 100 MB allocation in the
-    middleware). To avoid that:
+    To extract a CSRF token from a form body the middleware must buffer the
+    entire body — which would defeat Starlette's streaming for file uploads.
+    The following rules avoid that:
 
     * If ``X-CSRF-Token`` is present, the body is NOT read (zero buffer).
       Recommended for AJAX / fetch / non-browser clients.
     * For ``application/x-www-form-urlencoded`` (small forms), the body
-      is buffered up to ``config.CSRF_FORM_MAX_BODY_SIZE`` (default
-      1 MiB). Real urlencoded forms rarely exceed a few KB.
+      is buffered up to ``CSRF_FORM_MAX_BODY_SIZE`` (default **10 MB**).
+      Real urlencoded forms rarely exceed a few KB; the cap was bumped
+      from 1 MiB to 10 MB to match documented behavior (INV-015 instance
+      closed in v2.0.0).
     * For ``multipart/form-data``, the middleware refuses to buffer.
-      Multipart is the file-upload path — clients MUST send the token
-      via ``X-CSRF-Token`` header so we can validate without consuming
+      Multipart is the file-upload path — clients MUST send the token via
+      ``X-CSRF-Token`` header so validation can proceed without consuming
       the upload stream.
+    * For ``application/json``, the middleware always rejects without
+      reading the body when the header is absent.
+
+Send-wrapper (cookie issuance):
+    The middleware intercepts ``http.response.start`` and appends a
+    ``Set-Cookie`` header when the request carried no valid CSRF cookie
+    (i.e., ``scope['csrf_pending_cookie']`` is set).  The body is never
+    buffered by the send-wrapper (INV-002).
+
+First-request coordination:
+    When no valid CSRF cookie is present, the middleware generates the
+    full ``{nonce}.{sig}`` cookie value **before** calling downstream and
+    seeds it in ``scope['csrf_pending_cookie']``.  ``csrf_field`` and
+    ``csrf_token`` fall back to this value so that the rendered hidden
+    input and the issued ``Set-Cookie`` carry the same value in the same
+    request cycle.
+
+CSRF ⟂ session-revocation boundary:
+    The CSRF cookie is stateless and does not interact with session
+    revocation (INV-016).  A user with a revoked session still holds a
+    valid CSRF cookie; auth decorators (``login_required``, etc.) block
+    the request at the authorization layer before any handler runs.
+    Do NOT file "CSRF cookie outlives session revocation" as a finding.
 """
 
 from __future__ import annotations
 
+import base64
 import hmac
+import secrets
+from collections.abc import MutableMapping
+from hashlib import sha256
 from html import escape as _html_escape
-from typing import Any
+from typing import Protocol
 from urllib.parse import parse_qs
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -36,8 +85,21 @@ from core.logger import get_logger
 log = get_logger('csrf')
 
 _SAFE_METHODS = {'GET', 'HEAD', 'OPTIONS', 'TRACE'}
-_CSRF_SESSION_KEY = '_csrf_token'
-_DEFAULT_FORM_BODY_SIZE = 1 * 1024 * 1024  # 1 MiB — for urlencoded form parsing
+
+# Default urlencoded body cap — bumped from 1 MiB to 10 MB to match
+# documented behavior.  INV-015 instance closed in v2.0.0.
+_DEFAULT_FORM_BODY_SIZE = 10 * 1024 * 1024  # 10 MB
+
+# BREACH mask length in bytes.  Each render produces:
+#     _MASK_LEN bytes  ||  XOR(raw, _MASK_LEN-bytes-cycled)
+# → total bytes = _MASK_LEN + len(raw) → base64 of that.
+# For a 129-char raw cookie value: 32 + 129 = 161 bytes → 216 base64 chars.
+_MASK_LEN = 32
+
+
+# ---------------------------------------------------------------------------
+# Settings helpers (all via config.get — INV-029)
+# ---------------------------------------------------------------------------
 
 
 def _form_body_cap() -> int:
@@ -45,8 +107,241 @@ def _form_body_cap() -> int:
     return int(config.get('CSRF_FORM_MAX_BODY_SIZE', _DEFAULT_FORM_BODY_SIZE))
 
 
+def _cookie_name() -> str:
+    return str(config.get('CSRF_COOKIE_NAME', 'csrftoken'))
+
+
+# One-time guard so the __Host-/insecure misconfiguration warning fires once per
+# process, not on every cookie issuance (design §5 — loud, not spammy).
+_host_prefix_warned = False
+
+
+def _warn_host_prefix_insecure_once() -> None:
+    """Emit a one-time ``log.warning`` when ``CSRF_COOKIE_NAME`` uses the ``__Host-``
+    prefix while the configured ``CSRF_COOKIE_SECURE`` is ``False``.
+
+    The middleware still force-secures the cookie (a ``__Host-`` cookie requires
+    ``Secure`` or the browser rejects it); this warning is *in addition* to that,
+    so the misconfiguration is loud rather than silently corrected (design §5,
+    Decision 4).
+    """
+    global _host_prefix_warned
+    if _host_prefix_warned:
+        return
+    if not _cookie_name().startswith('__Host-'):
+        return
+    # Read the operator's RAW intent (default True), NOT the forced value.
+    configured_secure = bool(config.get('CSRF_COOKIE_SECURE', not config.get('DEBUG', False)))
+    if configured_secure:
+        return
+    _host_prefix_warned = True
+    log.warning(
+        'CSRF_COOKIE_NAME uses the __Host- prefix but CSRF_COOKIE_SECURE is False. '
+        'A __Host- cookie REQUIRES Secure; the middleware is force-securing the cookie, '
+        'but you should set CSRF_COOKIE_SECURE=True (and serve over HTTPS) to match.'
+    )
+
+
+def _cookie_secure() -> bool:
+    name = _cookie_name()
+    if name.startswith('__Host-'):
+        _warn_host_prefix_insecure_once()
+        return True  # __Host- requires Secure (forced; warning emitted above)
+    return bool(config.get('CSRF_COOKIE_SECURE', not config.get('DEBUG', False)))
+
+
+def _cookie_samesite() -> str:
+    return str(config.get('CSRF_COOKIE_SAMESITE', 'Lax'))
+
+
+def _cookie_httponly() -> bool:
+    # MUST default False — the JS shim reads document.cookie
+    return bool(config.get('CSRF_COOKIE_HTTPONLY', False))
+
+
+def _cookie_path() -> str:
+    name = _cookie_name()
+    if name.startswith('__Host-'):
+        return '/'  # __Host- requires Path=/
+    return str(config.get('CSRF_COOKIE_PATH', '/'))
+
+
+def _cookie_max_age() -> int | None:
+    value = config.get('CSRF_COOKIE_MAX_AGE', None)
+    return int(value) if value is not None else None
+
+
+# ---------------------------------------------------------------------------
+# HMAC helpers (REQ-CSRF-002, design §7)
+# ---------------------------------------------------------------------------
+
+
+def _sign_nonce(nonce: str) -> str:
+    """Return HMAC-SHA256(SECRET_KEY, nonce) as a hex string."""
+    key = config.SECRET_KEY.encode('utf-8')
+    return hmac.new(key, nonce.encode('utf-8'), sha256).hexdigest()
+
+
+def _cookie_signature_valid(cookie_val: str) -> bool:
+    """Return True iff ``cookie_val`` is a well-formed ``{nonce}.{sig}``
+    whose sig matches HMAC-SHA256(SECRET_KEY, nonce).
+
+    Returns False for any malformed or forged value.
+    """
+    if not cookie_val or '.' not in cookie_val:
+        return False
+    # Split at the LAST dot so nonces that happen to contain dots are handled
+    nonce, _, sig = cookie_val.rpartition('.')
+    if not nonce or not sig:
+        return False
+    try:
+        expected = _sign_nonce(nonce)
+        return hmac.compare_digest(sig, expected)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# BREACH masking helpers (design §2, REQ-CSRF-009)
+#
+# Mask envelope: _MASK_LEN random bytes prepended to XOR(raw_bytes, mask)
+#     where mask = os.urandom(_MASK_LEN) cycled over len(raw_bytes)
+# Base64-encode the whole envelope to get a URL-safe printable string.
+#
+# _looks_masked discriminator (what the code ACTUALLY checks):
+#     Raw cookie form:   exactly _RAW_COOKIE_LEN (129) chars AND every char in
+#                        [0-9a-fA-F.]  (64 hex + '.' + 64 hex). No dot-POSITION
+#                        check is performed — length + charset alone are decisive.
+#     Masked form:       a base64 envelope of (_MASK_LEN + len(raw)) bytes, whose
+#                        length is therefore always ≡ 0 (mod 4) after padding and,
+#                        for the 129-char raw cookie, is 216 chars (> 129).
+#     The two forms are DISJOINT because:
+#       - A 129-char string is not ≡ 0 (mod 4) (129 = 4*32 + 1), so it can never
+#         be a (padded) base64 envelope length — the masked branch can't produce it.
+#       - The masked base64 of a 161-byte envelope is 216 chars and carries
+#         upper-case letters and/or +/= absent from the raw [0-9a-fA-F.] charset.
+#     Hence a value matching the raw length+charset is unambiguously raw, and
+#     anything else is treated as masked.
+# ---------------------------------------------------------------------------
+
+_RAW_COOKIE_CHARSET = frozenset('0123456789abcdefABCDEF.')
+_RAW_COOKIE_LEN = 129  # 64 hex + '.' + 64 hex
+
+
+def _mask(raw: str) -> str:
+    """Return a base64-encoded BREACH-masked form of ``raw``.
+
+    Each call produces a different ciphertext for the same ``raw`` value
+    (per-render random mask).  ``_unmask`` is the inverse.
+    """
+    raw_bytes = raw.encode('utf-8')
+    mask_bytes = secrets.token_bytes(_MASK_LEN)
+    # XOR raw_bytes against mask_bytes cyclically
+    xored = bytes(b ^ mask_bytes[i % _MASK_LEN] for i, b in enumerate(raw_bytes))
+    envelope = mask_bytes + xored
+    return base64.b64encode(envelope).decode('ascii')
+
+
+def _unmask(masked: str) -> str:
+    """Reverse ``_mask``.  Raises ``ValueError`` on invalid input."""
+    try:
+        envelope = base64.b64decode(masked)
+    except Exception as exc:
+        raise ValueError(f'Invalid base64 in masked CSRF token: {exc}') from exc
+    if len(envelope) <= _MASK_LEN:
+        raise ValueError('Masked CSRF token envelope is too short')
+    mask_bytes = envelope[:_MASK_LEN]
+    xored = envelope[_MASK_LEN:]
+    raw_bytes = bytes(b ^ mask_bytes[i % _MASK_LEN] for i, b in enumerate(xored))
+    return raw_bytes.decode('utf-8')
+
+
+def _looks_masked(val: str) -> bool:
+    """Return True iff ``val`` looks like a BREACH-masked token.
+
+    Discriminates between:
+        * Raw cookie ``{nonce}.{sig}``:  exactly 129 chars, charset [0-9a-fA-F.]
+        * Masked envelope:              base64 string, always longer than 129 chars
+
+    Neither direction can produce a false positive:
+        - A raw 129-char hex.hex value is not a valid base64 encoding of a
+          161-byte sequence (which encodes to 216 base64 chars).
+        - A base64-encoded 161-byte sequence is always 216 chars and contains
+          upper-case letters and/or +/= that are absent from [0-9a-f.].
+
+    Returns False (treat as raw) if neither form matches unambiguously.
+    """
+    if not val:
+        return False
+    # Raw cookie: exactly _RAW_COOKIE_LEN chars AND every char in [0-9a-fA-F.].
+    # (No dot-position check — length + charset alone make raw and masked disjoint,
+    #  since 129 is not ≡ 0 mod 4 and so is never a valid base64 envelope length.)
+    if len(val) == _RAW_COOKIE_LEN and all(c in _RAW_COOKIE_CHARSET for c in val):
+        return False
+    # Anything else (longer, or carrying base64-only chars) is treated as masked.
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Set-Cookie header builder
+# ---------------------------------------------------------------------------
+
+
+def _build_set_cookie_header(cookie_val: str) -> bytes:
+    """Build the ``Set-Cookie`` header bytes for the CSRF cookie.
+
+    Enforces ``__Host-`` constraints when the configured cookie name starts
+    with ``__Host-``: forces ``Secure``, ``Path=/``, and suppresses ``Domain``.
+    """
+    name = _cookie_name()
+    parts = [f'{name}={cookie_val}']
+
+    # Path (always included; forced to / for __Host-)
+    path = _cookie_path()
+    parts.append(f'Path={path}')
+
+    # Secure
+    if _cookie_secure():
+        parts.append('Secure')
+
+    # HttpOnly
+    if _cookie_httponly():
+        parts.append('HttpOnly')
+
+    # SameSite
+    samesite = _cookie_samesite()
+    if samesite:
+        parts.append(f'SameSite={samesite}')
+
+    # Max-Age (omit for session cookie)
+    max_age = _cookie_max_age()
+    if max_age is not None:
+        parts.append(f'Max-Age={max_age}')
+
+    # __Host- prefix: NO Domain attribute (browser would reject it)
+    # For non-__Host- cookies, Domain is intentionally omitted (host-only scope)
+    # to avoid inadvertent subdomain sharing.
+
+    return ('; '.join(parts)).encode('latin1')
+
+
+# ---------------------------------------------------------------------------
+# CsrfMiddleware
+# ---------------------------------------------------------------------------
+
+
 class CsrfMiddleware:
-    """ASGI middleware that enforces CSRF tokens."""
+    """ASGI middleware enforcing signed double-submit cookie CSRF (v2.0.0).
+
+    Replaces the session-bound synchronizer token.  The middleware is
+    stateless: it reads ``scope['headers']`` for the incoming cookie and
+    writes ``scope['csrf_pending_cookie']`` when a fresh cookie must be
+    issued.  It does NOT read or write ``scope['session']``.
+
+    Args:
+        app:           The next ASGI application.
+        exempt_paths:  Paths that bypass CSRF validation for all methods.
+    """
 
     def __init__(self, app: ASGIApp, exempt_paths: list[str] | None = None) -> None:
         self.app = app
@@ -56,67 +351,81 @@ class CsrfMiddleware:
         if scope['type'] != 'http':
             return await self.app(scope, receive, send)
 
-        # Starlette SessionMiddleware populates scope['session'] as dict
-        session = scope.get('session')
+        # Parse cookies from incoming headers
+        raw_cookies = _parse_cookies(scope.get('headers', []))
+        cookie_name = _cookie_name()
+        cookie_val: str | None = raw_cookies.get(cookie_name)
 
-        # Ensure token exists
-        if session is not None and _CSRF_SESSION_KEY not in session:
-            session[_CSRF_SESSION_KEY] = Security.generate_csrf_token()
+        # Check whether the incoming cookie is valid; if not, generate a
+        # fresh one and seed it into scope before calling downstream.
+        # The send-wrapper will emit Set-Cookie on the live response.
+        if not cookie_val or not _cookie_signature_valid(cookie_val):
+            nonce = Security.generate_csrf_token()
+            sig = _sign_nonce(nonce)
+            cookie_val = f'{nonce}.{sig}'
+            scope['csrf_pending_cookie'] = cookie_val
 
         method = scope.get('method', 'GET')
-
-        if method in _SAFE_METHODS:
-            return await self.app(scope, receive, send)
-
         path = scope.get('path', '/')
-        if path in self.exempt_paths:
-            return await self.app(scope, receive, send)
 
+        # Safe methods and exempt paths: pass through with the send-wrapper
+        # so the cookie is issued (or not) based on scope['csrf_pending_cookie'].
+        if method in _SAFE_METHODS or path in self.exempt_paths:
+            return await self.app(scope, receive, _make_send_wrapper(scope, send))
+
+        # Unsafe method: two-check validation sequence
+        # Retrieve the live cookie value (may have been set above from a fresh one,
+        # but for a POST the cookie MUST have come from a previous GET — a newly
+        # generated pending cookie on a POST means the request arrived with no
+        # valid cookie at all, which we reject below).
+        live_cookie = raw_cookies.get(cookie_name)
+        if not live_cookie or not _cookie_signature_valid(live_cookie):
+            # No valid cookie present — cannot validate (check 1 has nothing to check against)
+            log.warning('CSRF check (1) failed: no valid cookie for %s %s', method, path)
+            return await _send_403(send)
+
+        # Check (1) is implicitly passed by _cookie_signature_valid above.
+        # Now determine the submitted token.
         headers = dict(scope.get('headers', []))
+        header_token_bytes = headers.get(b'x-csrf-token')
+
+        if header_token_bytes is not None:
+            # Header path — body NOT read (REQ-CSRF-003, INV-004)
+            submitted = header_token_bytes.decode('latin1', errors='replace')
+            if not _validate_submission(submitted, live_cookie):
+                log.warning('CSRF check (2) failed (header) for %s %s', method, path)
+                return await _send_403(send)
+            return await self.app(scope, receive, _make_send_wrapper(scope, send))
+
+        # No X-CSRF-Token header — inspect Content-Type
         content_type = headers.get(b'content-type', b'').decode('latin1', errors='replace')
-        expected = session.get(_CSRF_SESSION_KEY) if session else None
 
-        # 1. Header token — preferred. Validates without touching the body
-        #    so streaming uploads stay streamed.
-        token: str | None = None
-        header_token = headers.get(b'x-csrf-token')
-        if header_token:
-            token = header_token.decode('latin1', errors='replace')
-
-        if token is not None:
-            if not expected or not hmac.compare_digest(token, expected):
-                log.warning('CSRF validation failed (header) for %s %s', method, path)
-                return await self._send_403(send)
-            return await self.app(scope, receive, send)
-
-        # 2. No header. JSON clients must use the header — the body is
-        #    not parsed to avoid Content-Type-based bypass tricks.
         if 'application/json' in content_type:
+            # JSON clients must use the header (REQ-CSRF-004)
             log.warning('CSRF token missing (json no header) for %s %s', method, path)
-            return await self._send_403(send)
+            return await _send_403(send)
 
-        # 3. multipart/form-data: refuse to buffer. The token has to come
-        #    in the X-CSRF-Token header so we don't kill streaming.
         if 'multipart/form-data' in content_type:
+            # Refuse to buffer multipart (REQ-CSRF-005, INV-004)
             log.warning(
                 'CSRF token missing for multipart upload %s %s — multipart requires X-CSRF-Token header',
                 method,
                 path,
             )
-            return await self._send_403(send)
+            return await _send_403(send)
 
-        # 4. urlencoded form: buffer up to the cap, parse the token field.
+        # Urlencoded form body path (REQ-CSRF-006)
         try:
-            body = await self._read_body(receive, _form_body_cap())
+            body = await _read_body(receive, _form_body_cap())
         except ValueError:
-            return await self._send_413(send)
+            return await _send_413(send)
 
-        token = self._extract_form_token(body, content_type)
-        if not token or not expected or not hmac.compare_digest(token, expected):
-            log.warning('CSRF validation failed (form) for %s %s', method, path)
-            return await self._send_403(send)
+        form_token = _extract_form_token(body)
+        if not form_token or not _validate_submission(form_token, live_cookie):
+            log.warning('CSRF check (2) failed (form) for %s %s', method, path)
+            return await _send_403(send)
 
-        # Replay body so downstream can read it multiple times
+        # Replay body so downstream handlers can read it
         body_sent = False
 
         async def replay_receive() -> Message:
@@ -126,77 +435,203 @@ class CsrfMiddleware:
                 return {'type': 'http.request', 'body': body, 'more_body': False}
             return {'type': 'http.disconnect'}
 
-        await self.app(scope, replay_receive, send)
-
-    def _extract_form_token(self, body: bytes, content_type: str) -> str | None:
-        """Extract ``_csrf_token`` from a urlencoded body.
-
-        Multipart bodies never reach this function — see __call__: we
-        refuse them when the X-CSRF-Token header is missing, since
-        parsing multipart requires buffering the upload.
-        """
-        try:
-            parsed = parse_qs(body.decode('utf-8', errors='replace'))
-            values = parsed.get('_csrf_token', [])
-            return values[0] if values else None
-        except Exception:
-            return None
-
-    async def _read_body(self, receive: Receive, max_size: int) -> bytes:
-        """Read the ASGI request body up to ``max_size`` bytes.
-
-        Raises ``ValueError`` if the body exceeds the cap.
-        """
-        body: bytes = b''
-        while True:
-            message = await receive()
-            chunk: bytes = message.get('body', b'')
-            body += chunk
-            if len(body) > max_size:
-                raise ValueError(f'Body exceeds CSRF form cap ({max_size} bytes)')
-            if not message.get('more_body', False):
-                break
-        return body
-
-    async def _send_403(self, send: Send) -> None:
-        await send(
-            {
-                'type': 'http.response.start',
-                'status': 403,
-                'headers': [(b'content-type', b'text/plain; charset=utf-8')],
-            }
-        )
-        await send(
-            {
-                'type': 'http.response.body',
-                'body': b'403 Forbidden - CSRF token missing or invalid',
-            }
-        )
-
-    async def _send_413(self, send: Send) -> None:
-        """Send a 413 Payload Too Large response."""
-        await send(
-            {
-                'type': 'http.response.start',
-                'status': 413,
-                'headers': [(b'content-type', b'text/plain; charset=utf-8')],
-            }
-        )
-        await send(
-            {
-                'type': 'http.response.body',
-                'body': b'413 Payload Too Large',
-            }
-        )
+        await self.app(scope, replay_receive, _make_send_wrapper(scope, send))
 
 
-def csrf_field(session: dict[str, Any]) -> str:
-    """Return HTML hidden input with the CSRF token (XSS-safe)."""
-    token = _html_escape(session.get(_CSRF_SESSION_KEY, ''))
-    return f'<input type="hidden" name="_csrf_token" value="{token}">'
+# ---------------------------------------------------------------------------
+# Internal helpers (module-level functions, not methods — easier to test)
+# ---------------------------------------------------------------------------
 
 
-def csrf_token(session: dict[str, Any]) -> str:
-    """Return the raw CSRF token string."""
-    token: str = session.get(_CSRF_SESSION_KEY, '')
-    return token
+def _parse_cookies(headers: list[tuple[bytes, bytes]]) -> dict[str, str]:
+    """Parse the ``Cookie`` header from ASGI headers list into a dict."""
+    cookies: dict[str, str] = {}
+    for key, value in headers:
+        if key.lower() == b'cookie':
+            raw = value.decode('latin1', errors='replace')
+            for part in raw.split(';'):
+                part = part.strip()
+                if '=' in part:
+                    name, _, val = part.partition('=')
+                    cookies[name.strip()] = val.strip()
+    return cookies
+
+
+def _validate_submission(submitted: str, cookie_val: str) -> bool:
+    """Return True iff ``submitted`` (raw or masked) equals ``cookie_val``.
+
+    Unmasks ``submitted`` if ``_looks_masked`` identifies it as a BREACH envelope.
+    Uses ``hmac.compare_digest`` for constant-time comparison (check 2).
+    """
+    try:
+        candidate = _unmask(submitted) if _looks_masked(submitted) else submitted
+    except (ValueError, TypeError):
+        return False
+    # Compare BYTES, not str: ``_unmask`` can yield a valid-UTF-8 but non-ASCII
+    # ``str`` for an attacker-crafted masked token, and ``hmac.compare_digest``
+    # raises ``TypeError`` on non-ASCII ``str``. Encoding both sides keeps the
+    # comparison constant-time and content-agnostic — a non-ASCII candidate
+    # simply compares unequal and returns False (-> 403) instead of crashing.
+    return hmac.compare_digest(candidate.encode('utf-8'), cookie_val.encode('utf-8'))
+
+
+def _make_send_wrapper(scope: Scope, send: Send) -> Send:
+    """Return a send-wrapper that appends ``Set-Cookie`` to ``http.response.start``
+    iff ``scope['csrf_pending_cookie']`` is set.
+
+    The response body is never buffered (INV-002).
+    """
+    cookie_issued = False
+
+    async def wrapped_send(message: Message) -> None:
+        nonlocal cookie_issued
+        if message['type'] == 'http.response.start' and not cookie_issued:
+            pending = scope.get('csrf_pending_cookie')
+            if pending:
+                cookie_issued = True
+                cookie_bytes = _build_set_cookie_header(pending)
+                existing_headers = list(message.get('headers', []))
+                existing_headers.append((b'set-cookie', cookie_bytes))
+                message = {**message, 'headers': existing_headers}
+        await send(message)
+
+    return wrapped_send
+
+
+def _extract_form_token(body: bytes) -> str | None:
+    """Extract ``_csrf_token`` from a urlencoded body.
+
+    Multipart bodies never reach this function — the middleware rejects them
+    earlier when X-CSRF-Token is absent, since multipart parsing would
+    require buffering the entire upload.
+    """
+    try:
+        parsed = parse_qs(body.decode('utf-8', errors='replace'))
+        values = parsed.get('_csrf_token', [])
+        return values[0] if values else None
+    except Exception:
+        return None
+
+
+async def _read_body(receive: Receive, max_size: int) -> bytes:
+    """Read the ASGI request body up to ``max_size`` bytes.
+
+    Raises ``ValueError`` if the body exceeds the cap.
+    """
+    body: bytes = b''
+    while True:
+        message = await receive()
+        chunk: bytes = message.get('body', b'')
+        body += chunk
+        if len(body) > max_size:
+            raise ValueError(f'Body exceeds CSRF form cap ({max_size} bytes)')
+        if not message.get('more_body', False):
+            break
+    return body
+
+
+async def _send_403(send: Send) -> None:
+    await send(
+        {
+            'type': 'http.response.start',
+            'status': 403,
+            'headers': [(b'content-type', b'text/plain; charset=utf-8')],
+        }
+    )
+    await send(
+        {
+            'type': 'http.response.body',
+            'body': b'403 Forbidden - CSRF token missing or invalid',
+        }
+    )
+
+
+async def _send_413(send: Send) -> None:
+    """Send a 413 Payload Too Large response."""
+    await send(
+        {
+            'type': 'http.response.start',
+            'status': 413,
+            'headers': [(b'content-type', b'text/plain; charset=utf-8')],
+        }
+    )
+    await send(
+        {
+            'type': 'http.response.body',
+            'body': b'413 Payload Too Large',
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Template helpers
+# ---------------------------------------------------------------------------
+
+
+class _CsrfRequest(Protocol):
+    """Structural type for the objects ``csrf_field`` / ``csrf_token`` accept.
+
+    A Starlette ``starlette.requests.Request`` satisfies this Protocol, as does
+    any duck-typed object exposing the same two attributes. Using a Protocol
+    (rather than ``object``) makes the helpers' contract explicit per CLAUDE.md's
+    mandatory type-hint rule without importing Starlette at runtime.
+    """
+
+    cookies: dict[str, str]
+    scope: MutableMapping[str, object]
+
+
+def csrf_field(request: _CsrfRequest) -> str:
+    """Return an HTML hidden input with a BREACH-masked CSRF token.
+
+    Accepts a Starlette ``Request`` object (or any object with
+    ``.cookies: dict`` and ``.scope: dict``).
+
+    Resolution order:
+        1. ``request.cookies[CSRF_COOKIE_NAME]`` — present on all but the
+           first GET.
+        2. ``request.scope['csrf_pending_cookie']`` — seeded by
+           ``CsrfMiddleware`` before calling downstream on a first GET;
+           ensures the hidden input and the issued ``Set-Cookie`` carry the
+           same value in the same request cycle.
+
+    REQ-CSRF-009.
+    """
+    name = _cookie_name()
+    cookies: dict = getattr(request, 'cookies', {}) or {}
+    scope: dict = getattr(request, 'scope', {}) or {}
+    raw = cookies.get(name) or scope.get('csrf_pending_cookie', '')
+    masked = _mask(raw) if raw else ''
+    escaped = _html_escape(masked)
+    return f'<input type="hidden" name="_csrf_token" value="{escaped}">'
+
+
+def csrf_token(request: _CsrfRequest) -> str:
+    """Return the raw ``{nonce}.{sig}`` cookie value (not masked, not HMAC-only).
+
+    Accepts a Starlette ``Request`` object (or any object with
+    ``.cookies: dict`` and ``.scope: dict``).
+
+    Uses the same resolution order as ``csrf_field``.  Returns an empty
+    string when no value is available.
+
+    REQ-CSRF-010.
+    """
+    name = _cookie_name()
+    cookies: dict = getattr(request, 'cookies', {}) or {}
+    scope: dict = getattr(request, 'scope', {}) or {}
+    return str(cookies.get(name) or scope.get('csrf_pending_cookie', ''))
+
+
+def csrf_cookie_name() -> str:
+    """Return the configured CSRF cookie name (``config.get('CSRF_COOKIE_NAME', ...)``).
+
+    Exposed as a Jinja global so ``base.html`` can render the cookie name into the
+    page (``window.NORI_CSRF_COOKIE_NAME``) for the JS shim. The cookie NAME is
+    configuration, not a per-visitor secret, so rendering it is cache-safe and lets
+    the shim track an operator's ``__Host-csrftoken`` choice (Decision 4) without
+    editing ``csrf.js``.
+
+    REQ-CSRF-012, REQ-CSRF-013, design §5.
+    """
+    return _cookie_name()

--- a/rootsystem/application/core/jinja.py
+++ b/rootsystem/application/core/jinja.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from jinja2 import select_autoescape
 from starlette.templating import Jinja2Templates
 
-from core.auth.csrf import csrf_field
+from core.auth.csrf import csrf_cookie_name, csrf_field, csrf_token
 from core.conf import config
 from core.http.flash import get_flashed_messages
 from core.http.old import old
@@ -29,6 +29,8 @@ def _get_templates() -> Jinja2Templates:
         if config.get('DEBUG', False):
             _templates.env.auto_reload = True
         _templates.env.globals['csrf_field'] = csrf_field
+        _templates.env.globals['csrf_token'] = csrf_token
+        _templates.env.globals['csrf_cookie_name'] = csrf_cookie_name
         _templates.env.globals['get_flashed_messages'] = get_flashed_messages
         _templates.env.globals['old'] = old
     return _templates

--- a/rootsystem/application/settings.py
+++ b/rootsystem/application/settings.py
@@ -44,6 +44,18 @@ else:
         },
     }
 
+# CSRF — Signed double-submit cookie (v2.0.0)
+# All keys are read by core via config.get(key, default) — INV-029.
+# Override any of these in settings.py or via environment-specific config.
+CSRF_COOKIE_NAME = os.environ.get('CSRF_COOKIE_NAME', 'csrftoken')
+# Use '__Host-csrftoken' for single-host HTTPS deployments (Decision 4).
+CSRF_COOKIE_SECURE = not DEBUG  # True in production; forced True for __Host- names
+CSRF_COOKIE_SAMESITE = os.environ.get('CSRF_COOKIE_SAMESITE', 'Lax')
+CSRF_COOKIE_HTTPONLY = False  # MUST stay False — the JS shim reads document.cookie
+CSRF_COOKIE_PATH = os.environ.get('CSRF_COOKIE_PATH', '/')
+CSRF_COOKIE_MAX_AGE = None  # Session cookie by default; set to int seconds if needed
+CSRF_FORM_MAX_BODY_SIZE = int(os.environ.get('CSRF_FORM_MAX_BODY_SIZE', 10 * 1024 * 1024))  # 10 MB
+
 # CORS
 CORS_ORIGINS = [o.strip() for o in os.environ.get('CORS_ORIGINS', '').split(',') if o.strip()]
 CORS_ALLOW_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']

--- a/rootsystem/static/js/csrf.js
+++ b/rootsystem/static/js/csrf.js
@@ -1,0 +1,148 @@
+/**
+ * Nori CSRF shim — signed double-submit cookie (v2.0.0)
+ *
+ * Before any form is submitted, this shim reads the visitor's own CSRF cookie
+ * and writes its raw value into every <input name="_csrf_token"> field, replacing
+ * any stale server-rendered (possibly masked) value that may have been baked into
+ * a cached page by a different visitor.
+ *
+ * It also patches fetch() and XMLHttpRequest so that all same-origin unsafe
+ * requests carry X-CSRF-Token: <cookie value> automatically.
+ *
+ * Wire format: the cookie value IS the signed structure "{nonce}.{sig}".
+ * The shim copies this value raw — it performs no HMAC computation and requires
+ * no server secret. The server validates via two checks:
+ *   (1) Verify sig = HMAC-SHA256(SECRET_KEY, nonce) — detects forged cookies.
+ *   (2) Compare submitted value to cookie value — double-submit match.
+ *
+ * Cookie name: the shim reads CSRF_COOKIE_NAME from window.NORI_CSRF_COOKIE_NAME,
+ * which base.html renders from config BEFORE this script loads. This keeps the
+ * shim correct when an operator follows the design's __Host-csrftoken
+ * recommendation (Decision 4) without editing this file. The cookie NAME is
+ * configuration, not a per-visitor secret, so rendering it into the page is
+ * cache-safe. Falls back to 'csrftoken' if the global is absent.
+ *
+ * REQ-CSRF-012, design §5/§6.
+ */
+
+(function () {
+    'use strict';
+
+    // Name of the CSRF cookie. Sourced from the server-rendered global so it
+    // tracks CSRF_COOKIE_NAME in settings.py; defaults to 'csrftoken'.
+    var COOKIE_NAME = (typeof window !== 'undefined' && window.NORI_CSRF_COOKIE_NAME) || 'csrftoken';
+
+    /**
+     * Read a cookie value by name from document.cookie.
+     * Returns an empty string when the cookie is absent.
+     */
+    function readCookie(name) {
+        var prefix = name + '=';
+        var parts = document.cookie.split(';');
+        for (var i = 0; i < parts.length; i++) {
+            var part = parts[i].trim();
+            if (part.indexOf(prefix) === 0) {
+                return part.substring(prefix.length);
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Determine whether a URL is same-origin.
+     * Cross-origin requests must not carry the CSRF token.
+     */
+    function isSameOrigin(url) {
+        if (!url || url.charAt(0) === '/' || url.charAt(0) === '#' || url.charAt(0) === '?') {
+            return true;
+        }
+        try {
+            var target = new URL(url);
+            return target.origin === window.location.origin;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    var UNSAFE_METHODS = /^(POST|PUT|DELETE|PATCH)$/i;
+
+    /**
+     * Patch forms: on submit, overwrite _csrf_token fields with the visitor's
+     * own raw cookie value, correcting any stale cached value in the HTML.
+     */
+    function patchForms() {
+        document.addEventListener('submit', function (event) {
+            var form = event.target;
+            if (!form || !form.elements) {
+                return;
+            }
+            var tokenValue = readCookie(COOKIE_NAME);
+            if (!tokenValue) {
+                return;
+            }
+            var inputs = form.elements;
+            for (var i = 0; i < inputs.length; i++) {
+                if (inputs[i].name === '_csrf_token') {
+                    inputs[i].value = tokenValue;
+                }
+            }
+        }, true);
+    }
+
+    /**
+     * Patch fetch() to add X-CSRF-Token on same-origin unsafe requests.
+     */
+    function patchFetch() {
+        if (typeof window.fetch !== 'function') {
+            return;
+        }
+        var originalFetch = window.fetch.bind(window);
+        window.fetch = function (input, init) {
+            init = init || {};
+            var method = (init.method || 'GET').toUpperCase();
+            var url = (typeof input === 'string') ? input : (input.url || '');
+            if (UNSAFE_METHODS.test(method) && isSameOrigin(url)) {
+                var tokenValue = readCookie(COOKIE_NAME);
+                if (tokenValue) {
+                    var headers = new Headers(init.headers || {});
+                    if (!headers.has('X-CSRF-Token')) {
+                        headers.set('X-CSRF-Token', tokenValue);
+                    }
+                    init = Object.assign({}, init, { headers: headers });
+                }
+            }
+            return originalFetch(input, init);
+        };
+    }
+
+    /**
+     * Patch XMLHttpRequest to add X-CSRF-Token on same-origin unsafe requests.
+     */
+    function patchXHR() {
+        if (typeof XMLHttpRequest === 'undefined') {
+            return;
+        }
+        var originalOpen = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function (method, url) {
+            this._csrfMethod = method;
+            this._csrfUrl = url;
+            return originalOpen.apply(this, arguments);
+        };
+        var originalSend = XMLHttpRequest.prototype.send;
+        XMLHttpRequest.prototype.send = function () {
+            if (UNSAFE_METHODS.test(this._csrfMethod || '') && isSameOrigin(this._csrfUrl || '')) {
+                var tokenValue = readCookie(COOKIE_NAME);
+                if (tokenValue) {
+                    this.setRequestHeader('X-CSRF-Token', tokenValue);
+                }
+            }
+            return originalSend.apply(this, arguments);
+        };
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        patchForms();
+        patchFetch();
+        patchXHR();
+    });
+}());

--- a/rootsystem/templates/base.html
+++ b/rootsystem/templates/base.html
@@ -29,6 +29,14 @@
     <main>
         {% block content %}{% endblock %}
     </main>
+
+    <!-- Nori CSRF shim: before submit, copies this visitor's own CSRF cookie value into the
+         hidden _csrf_token field and sets X-CSRF-Token on fetch/XHR, so forms on cached pages
+         submit successfully even though the cached HTML carries a stranger's stale token.
+         The cookie NAME (config, not a per-visitor secret) is rendered here so the shim tracks
+         a custom CSRF_COOKIE_NAME (e.g. __Host-csrftoken) without editing csrf.js. Cache-safe. -->
+    <script>window.NORI_CSRF_COOKIE_NAME = {{ csrf_cookie_name()|tojson }};</script>
+    <script src="/static/js/csrf.js" defer></script>
 </body>
 
 </html>

--- a/tests/test_core/test_cache.py
+++ b/tests/test_core/test_cache.py
@@ -1065,3 +1065,275 @@ async def test_redis_atomic_update_modifies_existing(fake_redis_with_lua):
     result = await backend.atomic_update('counter', lambda v: v + 1)
     assert result == 6
     assert await backend.get('counter') == 6
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-017, design §1.5 — cache_response MUST NOT cache Set-Cookie
+# WU-1: RED tests for cache + CSRF interaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_response_never_emits_cached_set_cookie():
+    """A cache_response-served (cache-hit) response carries no Set-Cookie from the cache dict.
+
+    REQ-CSRF-017, design §1.5: the cache dict is exactly {body_b64, status_code, media_type}.
+    This test pins the existing correct behavior against regression.
+    """
+    from starlette.responses import Response
+
+    class FakeURL:
+        path = '/csrf-pin-test'
+        query = ''
+
+    class FakeRequest:
+        method = 'GET'
+        url = FakeURL()
+
+    class Ctrl:
+        @cache_response(ttl=60)
+        async def page(self, request):
+            return Response('<form>hi</form>', media_type='text/html', status_code=200)
+
+    ctrl = Ctrl()
+    req = FakeRequest()
+
+    # Warm the cache
+    resp1 = await ctrl.page(req)
+    assert resp1.status_code == 200
+
+    # Verify the cache dict does NOT contain Set-Cookie or any header data
+    backend = get_backend()
+    cache_key = 'view:/csrf-pin-test:'
+    cached = await backend.get(cache_key)
+    assert cached is not None, 'Cache entry was not created'
+    # The cached dict must contain ONLY these three keys (no headers)
+    assert set(cached.keys()) == {'body_b64', 'status_code', 'media_type'} or set(cached.keys()) == {
+        'body',
+        'status_code',
+        'media_type',
+    }, f'Cache dict must not contain headers; got keys: {set(cached.keys())}'
+    # Explicitly no Set-Cookie in the cached dict
+    assert 'set-cookie' not in cached
+    assert 'Set-Cookie' not in cached
+    assert 'headers' not in cached
+
+    # Cache-hit response must not carry Set-Cookie from the cache
+    resp2 = await ctrl.page(req)
+    # The Response object returned by cache_response on hit must not have Set-Cookie
+    # (cookie issuance is CsrfMiddleware's job, not cache_response's job)
+    if hasattr(resp2, 'headers'):
+        set_cookie_val = resp2.headers.get('set-cookie', '')
+        assert set_cookie_val == '', f'Cache-hit response must not replay Set-Cookie; got: {set_cookie_val!r}'
+
+
+def _extract_field_value(html: str, field_name: str = '_csrf_token') -> str:
+    """Pull the value of a named hidden input out of a rendered HTML form."""
+    import re
+
+    m = re.search(rf'name="{re.escape(field_name)}"\s+value="([^"]*)"', html)
+    if not m:
+        m = re.search(rf'value="([^"]*)"\s+name="{re.escape(field_name)}"', html)
+    assert m, f'No {field_name} hidden input found in: {html!r}'
+    return m.group(1)
+
+
+@pytest.mark.asyncio
+async def test_cross_visitor_cached_page_submit_with_shim_succeeds():
+    """Genuine cross-visitor cache-hit + shim scenario.
+
+    REQ-CSRF-011 / REQ-CSRF-017: a `cache_response`-decorated form page is warmed by
+    Visitor A (cookie A; the cached HTML embeds A's masked token). Visitor B GETs the
+    SAME page through the real CsrfMiddleware + cache_response stack and:
+
+      (a) receives a cache HIT serving A's cached body (A's stale embedded token), AND
+      (b) receives their OWN distinct Set-Cookie (cookie B != cookie A) from the
+          live send-wrapper (the cache layer never replays Set-Cookie — §1.5).
+
+    The shim then copies B's OWN raw cookie value into X-CSRF-Token before submit, and
+    B's POST validates (200). A control assertion (B replays A's stale cached field with
+    no shim) is covered by test_cross_visitor_cached_page_submit_without_shim_403s.
+    """
+    from core.auth.csrf import CsrfMiddleware, csrf_field
+    from starlette.responses import Response
+
+    from tests.test_core.test_csrf import (
+        _Captured,
+        _make_receive,
+        _passthrough_app,
+        _scope,
+        _scope_with_cookie,
+    )
+
+    # --- The cached form page. csrf_field embeds the warming visitor's masked token. ---
+    class FormCtrl:
+        @cache_response(ttl=60)
+        async def form_page(self, request):
+            field = csrf_field(request)
+            return Response(f'<form method="post">{field}</form>', media_type='text/html')
+
+    ctrl = FormCtrl()
+
+    class FakeURL:
+        path = '/cached-form'
+        query = ''
+
+    class CacheRequest:
+        """Request shim that cache_response and csrf_field both understand."""
+
+        method = 'GET'
+        url = FakeURL()
+
+        def __init__(self, scope: dict):
+            self.scope = scope
+            # Cookies parsed off the incoming Cookie header, plus any pending cookie.
+            self.cookies: dict[str, str] = {}
+            for key, value in scope.get('headers', []):
+                if key.lower() == b'cookie':
+                    raw = value.decode('latin1')
+                    for part in raw.split(';'):
+                        if '=' in part:
+                            name, _, val = part.partition('=')
+                            self.cookies[name.strip()] = val.strip()
+
+    # --- Visitor A: first GET, no cookie. CsrfMiddleware seeds a pending cookie, the
+    #     handler renders csrf_field(A's pending cookie), the cache stores A's body, and
+    #     the send-wrapper issues Set-Cookie: csrftoken=cookie_A on A's live response. ---
+    scope_a = _scope('GET', path='/cached-form')
+    cap_a = _Captured()
+
+    async def app_a(scope, receive, send):
+        resp = await ctrl.form_page(CacheRequest(scope))
+        await resp(scope, receive, send)
+
+    mw = CsrfMiddleware(app_a)
+    await mw(scope_a, await _make_receive(), cap_a.send)
+
+    assert cap_a.status == 200
+    set_cookies_a = [c for c in cap_a.set_cookie_headers() if 'csrftoken=' in c]
+    assert set_cookies_a, 'Visitor A must receive a Set-Cookie issuing their per-visitor cookie'
+    cookie_a = set_cookies_a[0].split('csrftoken=')[1].split(';')[0].strip()
+    cached_field_a = _extract_field_value(cap_a.body.decode())
+
+    # --- Visitor B: GET the SAME page WITH their own pre-existing valid cookie.
+    #     cache_response serves A's cached body (cache HIT — A's stale masked field),
+    #     while CsrfMiddleware leaves B's own cookie in place (no reissue). ---
+    from tests.test_core.test_csrf import _signed_cookie
+
+    _nonce_b, cookie_b = _signed_cookie()
+    assert cookie_b != cookie_a, 'Per-visitor cookies must differ (B != A)'
+
+    scope_b = _scope_with_cookie('GET', 'csrftoken', cookie_b)
+    scope_b['path'] = '/cached-form'
+    cap_b = _Captured()
+
+    async def app_b(scope, receive, send):
+        resp = await ctrl.form_page(CacheRequest(scope))
+        await resp(scope, receive, send)
+
+    mw_b = CsrfMiddleware(app_b)
+    await mw_b(scope_b, await _make_receive(), cap_b.send)
+
+    assert cap_b.status == 200
+    # B was served A's CACHED body — the embedded field is A's stale masked token.
+    served_field_b = _extract_field_value(cap_b.body.decode())
+    assert served_field_b == cached_field_a, (
+        "Visitor B must receive a cache HIT serving A's cached body (A's stale token)"
+    )
+    # B holds their OWN distinct cookie (already present — not reissued, not A's).
+    reissued_b = [c for c in cap_b.set_cookie_headers() if 'csrftoken=' in c]
+    assert not reissued_b, 'B already holds a valid cookie; it must not be reissued by the cache hit'
+
+    # --- The shim: before submit, B copies B's OWN raw cookie value into X-CSRF-Token,
+    #     overwriting the stale cached field. B's POST must validate (200). ---
+    post_scope_b = _scope_with_cookie('POST', 'csrftoken', cookie_b, headers=[(b'x-csrf-token', cookie_b.encode())])
+    cap_post = _Captured()
+    mw_post = CsrfMiddleware(_passthrough_app)
+    await mw_post(post_scope_b, await _make_receive(), cap_post.send)
+    assert cap_post.status == 200, (
+        f"With the shim, B submitting B's own raw cookie value must succeed; got {cap_post.status}"
+    )
+
+    # --- Control: WITHOUT the shim, B submits the stale cached field (A's masked token)
+    #     against B's own cookie -> 403 (documented no-JS limitation, not a bypass). ---
+    from urllib.parse import urlencode
+
+    body_no_shim = urlencode({'_csrf_token': served_field_b}).encode()
+    post_scope_no_shim = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_b,
+        headers=[(b'content-type', b'application/x-www-form-urlencoded')],
+    )
+    cap_no_shim = _Captured()
+    mw_no_shim = CsrfMiddleware(_passthrough_app)
+    await mw_no_shim(post_scope_no_shim, await _make_receive(body_no_shim), cap_no_shim.send)
+    assert cap_no_shim.status == 403, (
+        f"Without the shim, B replaying A's stale cached field must 403; got {cap_no_shim.status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cross_visitor_cached_page_submit_without_shim_403s():
+    """Visitor B submits A's stale cached field value (no shim correction) -> 403.
+
+    REQ-CSRF-011: documented no-JS limitation for cached form pages.
+    """
+    import hmac as _hmac
+    import secrets
+
+    import settings
+    from core.auth.csrf import CsrfMiddleware
+
+    # Visitor A's cookie (warmed the cache)
+    nonce_a = secrets.token_hex(32)
+    sig_a = _hmac.new(settings.SECRET_KEY.encode(), nonce_a.encode(), 'sha256').hexdigest()
+    cookie_a = f'{nonce_a}.{sig_a}'
+
+    # Visitor B's cookie
+    nonce_b = secrets.token_hex(32)
+    sig_b = _hmac.new(settings.SECRET_KEY.encode(), nonce_b.encode(), 'sha256').hexdigest()
+    cookie_b = f'{nonce_b}.{sig_b}'
+
+    # B submits A's stale cached field value (no shim to correct it)
+    # The urlencoded body contains A's raw cookie value as _csrf_token
+    body = f'_csrf_token={cookie_a}&name=alice'.encode()
+
+    from tests.test_core.test_csrf import _Captured, _make_receive, _passthrough_app, _scope_with_cookie
+
+    scope_b = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_b,  # B's own cookie in the browser
+        headers=[(b'content-type', b'application/x-www-form-urlencoded')],
+    )
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope_b, await _make_receive(body), cap.send)
+    assert cap.status == 403, f"Without shim, B submitting A's stale token must fail with 403; got {cap.status}"
+
+
+@pytest.mark.asyncio
+async def test_forged_cookie_writer_attack_fails():
+    """Attacker sets cookie {nonce}.{bad_sig} + submits same value -> 403 at check (1).
+
+    REQ-CSRF-002, REQ-CSRF-003: writer-attacker cannot forge a valid signature.
+    """
+    import secrets
+
+    from core.auth.csrf import CsrfMiddleware
+
+    nonce = secrets.token_hex(32)
+    bad_sig = 'c' * 64  # not a valid HMAC under SECRET_KEY
+    forged_cookie = f'{nonce}.{bad_sig}'
+
+    from tests.test_core.test_csrf import _Captured, _make_receive, _passthrough_app, _scope_with_cookie
+
+    headers = [(b'x-csrf-token', forged_cookie.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', forged_cookie, headers=headers)
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 403, f'Forged cookie (bad sig) must be rejected at check (1) with 403; got {cap.status}'

--- a/tests/test_core/test_csrf.py
+++ b/tests/test_core/test_csrf.py
@@ -1,32 +1,57 @@
-"""Tests for CSRF middleware and helpers."""
+"""Tests for CSRF middleware and helpers.
 
+Baseline before csrf-double-submit: 1039 passed, 1 pre-existing failure
+(test_throttle_backends::test_redis_check_and_add_refuses_when_at_limit),
+27 CSRF tests (all passing with session-bound implementation).
+
+WU-1: RED suite for signed double-submit cookie contract.
+All new tests in this file MUST fail against the session-bound implementation
+and MUST pass after WU-2 (the signed double-submit rewrite).
+
+Surviving tests from the old suite that pin INV-004 behavior:
+  - test_multipart_without_header_is_refused   (unchanged)
+  - test_form_body_cap_is_configurable         (unchanged, still uses monkeypatch)
+  - test_websocket_scope_passes_through        (renamed from test_non_http_scope_passes)
+  - test_safe_method_passes_through            (new name for GET/HEAD/OPTIONS group)
+"""
+
+from __future__ import annotations
+
+import base64
+import hmac
 from urllib.parse import urlencode
 
 import pytest
-from core.auth.csrf import _CSRF_SESSION_KEY, CsrfMiddleware, csrf_field, csrf_token
+from core.auth.csrf import CsrfMiddleware, csrf_field, csrf_token
 from core.auth.security import Security
 
 # ---------------------------------------------------------------------------
-# Helpers to simulate ASGI calls
+# ASGI test helpers
 # ---------------------------------------------------------------------------
 
 
 class _Captured:
-    """Captures ASGI response messages."""
+    """Captures ASGI response messages, including headers."""
 
-    def __init__(self):
-        self.status = None
+    def __init__(self) -> None:
+        self.status: int | None = None
+        self.headers: list[tuple[bytes, bytes]] = []
         self.body = b''
 
-    async def send(self, message):
+    async def send(self, message: dict) -> None:
         if message['type'] == 'http.response.start':
             self.status = message['status']
+            self.headers = list(message.get('headers', []))
         elif message['type'] == 'http.response.body':
             self.body += message.get('body', b'')
 
+    def set_cookie_headers(self) -> list[str]:
+        """Return all Set-Cookie header values as decoded strings."""
+        return [v.decode('latin1') for k, v in self.headers if k.lower() == b'set-cookie']
+
 
 async def _make_receive(body: bytes = b''):
-    """Return an ASGI receive callable that returns the given body."""
+    """Return an ASGI receive callable that returns the given body once."""
     sent = False
 
     async def receive():
@@ -45,276 +70,524 @@ async def _passthrough_app(scope, receive, send):
     await send({'type': 'http.response.body', 'body': b'OK'})
 
 
-def _scope(method='GET', path='/', session=None, headers=None, content_type=None):
-    """Build a minimal ASGI HTTP scope."""
-    h = list(headers or [])
+def _scope(
+    method: str = 'GET',
+    path: str = '/',
+    headers: list[tuple[bytes, bytes]] | None = None,
+    content_type: str | None = None,
+    cookie: str | None = None,
+) -> dict:
+    """Build a minimal ASGI HTTP scope without a session key."""
+    h: list[tuple[bytes, bytes]] = list(headers or [])
     if content_type:
         h.append((b'content-type', content_type.encode('latin1')))
-    s = {
+    if cookie:
+        h.append((b'cookie', cookie.encode('latin1')))
+    return {
         'type': 'http',
         'method': method,
         'path': path,
         'headers': h,
     }
-    if session is not None:
-        s['session'] = session
-    return s
+
+
+def _scope_with_cookie(
+    method: str,
+    cookie_name: str,
+    cookie_value: str,
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> dict:
+    """Build an ASGI scope with the given cookie; no session key."""
+    cookie_str = f'{cookie_name}={cookie_value}'
+    h: list[tuple[bytes, bytes]] = list(headers or [])
+    h.append((b'cookie', cookie_str.encode('latin1')))
+    return {
+        'type': 'http',
+        'method': method,
+        'path': '/',
+        'headers': h,
+    }
+
+
+def _signed_cookie(secret: str | None = None, nonce: str | None = None) -> tuple[str, str]:
+    """Return (nonce, cookie_value) where cookie_value = '{nonce}.{sig}'.
+
+    Uses the actual SECRET_KEY from settings so cookies validate correctly
+    under the live CsrfMiddleware instance.
+    """
+    if secret is None:
+        import settings
+
+        secret = settings.SECRET_KEY
+    if nonce is None:
+        nonce = Security.generate_csrf_token()
+    sig = hmac.new(secret.encode(), nonce.encode(), 'sha256').hexdigest()
+    return nonce, f'{nonce}.{sig}'
 
 
 # ---------------------------------------------------------------------------
-# csrf_field / csrf_token helpers
-# ---------------------------------------------------------------------------
-
-
-def test_csrf_field_returns_html():
-    session = {_CSRF_SESSION_KEY: 'abc123'}
-    html = csrf_field(session)
-    assert 'value="abc123"' in html
-    assert 'name="_csrf_token"' in html
-    assert '<input' in html
-
-
-def test_csrf_field_escapes_xss():
-    session = {_CSRF_SESSION_KEY: '"><script>alert(1)</script>'}
-    html = csrf_field(session)
-    assert '<script>' not in html
-    assert '&lt;script&gt;' in html
-
-
-def test_csrf_field_empty_session():
-    html = csrf_field({})
-    assert 'value=""' in html
-
-
-def test_csrf_token_returns_raw_string():
-    session = {_CSRF_SESSION_KEY: 'mytoken'}
-    assert csrf_token(session) == 'mytoken'
-
-
-def test_csrf_token_empty_session():
-    assert csrf_token({}) == ''
-
-
-# ---------------------------------------------------------------------------
-# Middleware: safe methods pass through
+# REQ-CSRF-003 — raw token acceptance
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_request_passes():
-    session = {}
-    scope = _scope('GET', session=session)
+async def test_validate_accepts_raw_cookie_value():
+    """POST with X-CSRF-Token = raw cookie value (what the shim sends) -> 200.
+
+    REQ-CSRF-003 check (2): submitted == cookie_value (raw, not masked).
+    Session must NOT be required (REQ-CSRF-014).
+    """
+    _nonce, cookie_val = _signed_cookie()
+    headers = [(b'x-csrf-token', cookie_val.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val, headers=headers)
+    # No 'session' key in scope — proving stateless validation
+    assert 'session' not in scope
+
     cap = _Captured()
     mw = CsrfMiddleware(_passthrough_app)
     await mw(scope, await _make_receive(), cap.send)
     assert cap.status == 200
-    # Token should be auto-generated in session
-    assert _CSRF_SESSION_KEY in session
 
 
 @pytest.mark.asyncio
-async def test_head_request_passes():
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(_scope('HEAD', session={}), await _make_receive(), cap.send)
-    assert cap.status == 200
+async def test_validate_accepts_masked_cookie_value():
+    """POST with X-CSRF-Token = mask(cookie_value) -> 200 (dual-accept).
 
-
-@pytest.mark.asyncio
-async def test_options_request_passes():
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(_scope('OPTIONS', session={}), await _make_receive(), cap.send)
-    assert cap.status == 200
-
-
-# ---------------------------------------------------------------------------
-# Middleware: POST without token -> 403
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_post_without_token_returns_403():
-    session = {_CSRF_SESSION_KEY: Security.generate_csrf_token()}
-    body = urlencode({'name': 'test'}).encode()
-    scope = _scope('POST', session=session, content_type='application/x-www-form-urlencoded')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(body), cap.send)
-    assert cap.status == 403
-
-
-@pytest.mark.asyncio
-async def test_post_with_wrong_token_returns_403():
-    session = {_CSRF_SESSION_KEY: Security.generate_csrf_token()}
-    body = urlencode({'_csrf_token': 'wrong-token'}).encode()
-    scope = _scope('POST', session=session, content_type='application/x-www-form-urlencoded')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(body), cap.send)
-    assert cap.status == 403
-
-
-# ---------------------------------------------------------------------------
-# Middleware: valid token passes
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_post_with_valid_token_passes():
-    token = Security.generate_csrf_token()
-    session = {_CSRF_SESSION_KEY: token}
-    body = urlencode({'_csrf_token': token}).encode()
-    scope = _scope('POST', session=session, content_type='application/x-www-form-urlencoded')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(body), cap.send)
-    assert cap.status == 200
-
-
-@pytest.mark.asyncio
-async def test_post_with_header_token_passes():
-    token = Security.generate_csrf_token()
-    session = {_CSRF_SESSION_KEY: token}
-    headers = [(b'x-csrf-token', token.encode())]
-    scope = _scope('POST', session=session, headers=headers, content_type='application/x-www-form-urlencoded')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(b''), cap.send)
-    assert cap.status == 200
-
-
-# ---------------------------------------------------------------------------
-# JSON requests require the X-CSRF-Token header (no Content-Type bypass)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_json_post_without_token_returns_403():
-    session = {_CSRF_SESSION_KEY: Security.generate_csrf_token()}
-    scope = _scope('POST', session=session, content_type='application/json')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(b'{"key": "value"}'), cap.send)
-    assert cap.status == 403
-
-
-@pytest.mark.asyncio
-async def test_json_post_with_header_token_passes():
-    token = Security.generate_csrf_token()
-    session = {_CSRF_SESSION_KEY: token}
-    headers = [(b'x-csrf-token', token.encode())]
-    scope = _scope('POST', session=session, headers=headers, content_type='application/json')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(b'{"key": "value"}'), cap.send)
-    assert cap.status == 200
-
-
-# ---------------------------------------------------------------------------
-# Exempt paths
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_exempt_path_passes():
-    session = {_CSRF_SESSION_KEY: Security.generate_csrf_token()}
-    scope = _scope('POST', path='/api/webhook', session=session, content_type='application/x-www-form-urlencoded')
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app, exempt_paths={'/api/webhook'})
-    await mw(scope, await _make_receive(b'no_token=1'), cap.send)
-    assert cap.status == 200
-
-
-# ---------------------------------------------------------------------------
-# Multipart form data
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_multipart_without_header_is_refused():
-    """Multipart bodies must NOT be buffered in the middleware — they're
-    the upload path. Clients must send the token in X-CSRF-Token instead.
-
-    Pre-1.22.0, the middleware would buffer the entire upload (up to
-    10 MB) just to extract the form token, killing Starlette's streaming
-    and turning a single 10 MB request into a 10 MB middleware allocation.
+    REQ-CSRF-003, design §2: server unmasks before comparing.
     """
-    token = Security.generate_csrf_token()
-    session = {_CSRF_SESSION_KEY: token}
-    body = (
-        b'------WebKitFormBoundary7MA4YWxk\r\n'
-        b'Content-Disposition: form-data; name="_csrf_token"\r\n'
-        b'\r\n' + token.encode() + b'\r\n------WebKitFormBoundary7MA4YWxk--\r\n'
-    )
-    scope = _scope(
-        'POST',
-        session=session,
-        content_type='multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxk',
-    )
+    from core.auth.csrf import _mask  # will exist after WU-2
+
+    _nonce, cookie_val = _signed_cookie()
+    masked = _mask(cookie_val)
+    headers = [(b'x-csrf-token', masked.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val, headers=headers)
+
     cap = _Captured()
     mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(body), cap.send)
-    assert cap.status == 403
-
-
-@pytest.mark.asyncio
-async def test_multipart_with_header_passes_without_buffering():
-    """Multipart with X-CSRF-Token header passes through — body is NOT consumed."""
-    token = Security.generate_csrf_token()
-    session = {_CSRF_SESSION_KEY: token}
-    # 5 MiB body — well above any sane form cap. With the old code this
-    # would be buffered into the middleware. With the fix, the header
-    # short-circuits validation and the body streams to the handler.
-    body = b'fake upload bytes' * (5 * 1024 * 1024 // 17)
-    scope = _scope(
-        'POST',
-        session=session,
-        content_type='multipart/form-data; boundary=----xx',
-        headers=[(b'x-csrf-token', token.encode())],
-    )
-    cap = _Captured()
-    mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(body), cap.send)
+    await mw(scope, await _make_receive(), cap.send)
     assert cap.status == 200
 
 
 @pytest.mark.asyncio
-async def test_header_token_is_validated_without_reading_body():
-    """If X-CSRF-Token is present, the middleware must NOT consume the body."""
-    token = Security.generate_csrf_token()
-    session = {_CSRF_SESSION_KEY: token}
-    scope = _scope(
-        'POST',
-        session=session,
-        content_type='application/x-www-form-urlencoded',
-        headers=[(b'x-csrf-token', token.encode())],
-    )
+async def test_validate_rejects_signature_invalid_cookie():
+    """Cookie = {nonce}.{wrong_sig} + submitted = same cookie -> 403 at check (1).
 
-    # A receive that records whether it was called.
-    consumed = {'count': 0}
+    REQ-CSRF-002, REQ-CSRF-003: forged cookie (wrong sig under SECRET_KEY).
+    This is the writer-attacker defense.
+    """
+    nonce = Security.generate_csrf_token()
+    bad_sig = 'a' * 64  # not a valid HMAC under SECRET_KEY
+    forged_cookie = f'{nonce}.{bad_sig}'
+    headers = [(b'x-csrf-token', forged_cookie.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', forged_cookie, headers=headers)
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 403
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_unsigned_naive_double_submit():
+    """Cookie = bare nonce (no .sig), submitted == cookie -> 403.
+
+    REQ-CSRF-002: variant-a (unsigned double-submit) is closed.
+    A bare nonce must fail signature check (1) — it has no valid sig part.
+    """
+    bare_nonce = Security.generate_csrf_token()  # 64 hex chars, no dot
+    headers = [(b'x-csrf-token', bare_nonce.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', bare_nonce, headers=headers)
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 403
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_mismatched_submission():
+    """Valid signed cookie but X-CSRF-Token belongs to a different cookie -> 403 at check (2).
+
+    REQ-CSRF-003: the submitted value must match THIS visitor's cookie.
+    """
+    _nonce1, cookie_val1 = _signed_cookie()
+    _nonce2, cookie_val2 = _signed_cookie()  # different nonce/sig pair
+    # Cookie is cookie_val1 but header carries cookie_val2
+    headers = [(b'x-csrf-token', cookie_val2.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val1, headers=headers)
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 403
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-003 / REQ-CSRF-006 — non-ASCII unmask must not crash (DoS guard)
+#
+# `_unmask` ends in `raw_bytes.decode('utf-8')`, so an attacker-crafted masked
+# token can unmask to a VALID-UTF-8 but NON-ASCII str. `hmac.compare_digest`
+# on a non-ASCII str raises TypeError. `_validate_submission` must compare
+# bytes so the crafted token simply returns False (-> 403) instead of letting
+# the TypeError escape the middleware (500 / DoS).
+# ---------------------------------------------------------------------------
+
+
+def _craft_non_ascii_unmask_token() -> str:
+    """Build a masked token that unmasks to a valid-UTF-8 NON-ASCII str.
+
+    With a zero mask, the XORed bytes equal the desired payload verbatim, so the
+    envelope unmasks to ('é' * 40), which `str.decode('utf-8')` accepts but
+    `hmac.compare_digest` rejects with TypeError when compared as a str.
+    """
+    from core.auth.csrf import _MASK_LEN
+
+    desired = ('é' * 40).encode('utf-8')
+    mask = b'\x00' * _MASK_LEN
+    return base64.b64encode(mask + desired).decode('ascii')
+
+
+def test_validate_submission_non_ascii_unmask_returns_false_not_raises():
+    """Unit: a token unmasking to non-ASCII returns False (must NOT raise TypeError).
+
+    Regression for the DoS: `hmac.compare_digest` on a non-ASCII str raises
+    TypeError, which `_validate_submission` only-catching-ValueError let escape.
+    """
+    from core.auth.csrf import _validate_submission
+
+    crafted = _craft_non_ascii_unmask_token()
+    cookie_val = 'a' * 64 + '.' + 'b' * 64
+    # Must return a bool (False), not raise.
+    assert _validate_submission(crafted, cookie_val) is False
+
+
+def test_validate_submission_ascii_wrong_masked_token_returns_false():
+    """Unit: a plain ASCII-but-wrong masked token still returns False (no regression)."""
+    from core.auth.csrf import _mask, _validate_submission
+
+    _nonce, cookie_val = _signed_cookie()
+    _nonce2, other_cookie = _signed_cookie()
+    wrong_masked = _mask(other_cookie)  # masks a DIFFERENT cookie value
+    assert _validate_submission(wrong_masked, cookie_val) is False
+
+
+def test_validate_submission_legitimate_masked_token_roundtrips():
+    """Unit: a legitimate _mask(cookie) still validates (round-trip not broken)."""
+    from core.auth.csrf import _mask, _validate_submission
+
+    _nonce, cookie_val = _signed_cookie()
+    legit_masked = _mask(cookie_val)
+    assert _validate_submission(legit_masked, cookie_val) is True
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_unmask_header_returns_403_not_500():
+    """Integration: a valid signed cookie + crafted non-ASCII-unmask token in the
+    X-CSRF-Token header returns 403 — the middleware must NOT let the TypeError
+    propagate as an unhandled 500.
+
+    REQ-CSRF-003, REQ-CSRF-006 (any invalid token -> 403).
+    """
+    _nonce, cookie_val = _signed_cookie()
+    crafted = _craft_non_ascii_unmask_token()
+    headers = [(b'x-csrf-token', crafted.encode('latin1'))]
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val, headers=headers)
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    # Must not raise; must answer 403.
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 403
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-009 — BREACH masking: per-render masks differ, both validate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_masked_token_differs_per_render():
+    """Two csrf_field(request) calls produce different masked values
+    for the same cookie, but both must unmasked-equal the cookie value.
+
+    REQ-CSRF-009, design §2.
+    """
+    from core.auth.csrf import _unmask  # will exist after WU-2
+
+    _nonce, cookie_val = _signed_cookie()
+
+    class _FakeRequest:
+        cookies = {'csrftoken': cookie_val}
+        scope: dict = {}
+
+    req = _FakeRequest()
+    html1 = csrf_field(req)
+    html2 = csrf_field(req)
+
+    # Extract the masked value from the hidden input
+    import re
+
+    def _extract_value(html: str) -> str:
+        m = re.search(r'value="([^"]+)"', html)
+        assert m, f'No value= in: {html!r}'
+        return m.group(1)
+
+    val1 = _extract_value(html1)
+    val2 = _extract_value(html2)
+
+    # Per-render masks produce different ciphertexts
+    assert val1 != val2, 'Two renders should produce different masked values (BREACH resistance)'
+
+    # Both unmask to the same raw cookie value
+    assert _unmask(val1) == cookie_val
+    assert _unmask(val2) == cookie_val
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-014 — no session dependency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_no_session_dependency():
+    """Validation passes with scope['session'] absent (stateless).
+
+    REQ-CSRF-014.
+    """
+    _nonce, cookie_val = _signed_cookie()
+    headers = [(b'x-csrf-token', cookie_val.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val, headers=headers)
+    # Explicitly confirm no session key
+    assert 'session' not in scope
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 200
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-003 — header token short-circuits body read (INV-004 preserved)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_header_token_path_still_short_circuits():
+    """X-CSRF-Token supplied -> body NOT read; 200 returned.
+
+    REQ-CSRF-003, INV-004.
+    """
+    _nonce, cookie_val = _signed_cookie()
+    headers = [(b'x-csrf-token', cookie_val.encode())]
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val, headers=headers)
+
+    body_read = {'count': 0}
 
     async def tracking_receive():
-        consumed['count'] += 1
+        body_read['count'] += 1
         return {'type': 'http.request', 'body': b'_csrf_token=irrelevant', 'more_body': False}
 
     cap = _Captured()
     mw = CsrfMiddleware(_passthrough_app)
     await mw(scope, tracking_receive, cap.send)
     assert cap.status == 200
-    # The middleware passed receive through to the app — we can't fully
-    # observe whether the app called it (it's _passthrough_app), but we
-    # know the middleware itself didn't read it (it short-circuited
-    # before _read_body).
+    # The middleware should NOT have consumed the body for header validation
+    assert body_read['count'] == 0, 'Middleware must not read body when X-CSRF-Token header is present'
 
 
 # ---------------------------------------------------------------------------
-# Non-HTTP scope passes through
+# REQ-CSRF-003 — no cookie -> 403
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_non_http_scope_passes():
+async def test_no_cookie_rejects():
+    """Unsafe method with no CSRF cookie present -> 403 (no nonce to verify).
+
+    REQ-CSRF-003.
+    """
+    # No cookie in scope headers at all
+    scope = _scope('POST', content_type='application/x-www-form-urlencoded')
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    body = urlencode({'_csrf_token': 'anything'}).encode()
+    await mw(scope, await _make_receive(body), cap.send)
+    assert cap.status == 403
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-007 / REQ-CSRF-006 — body cap default = 10 MB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_form_body_cap_default_is_10mb():
+    """_form_body_cap() returns 10 * 1024 * 1024; a 1.5 MB body is accepted.
+
+    REQ-CSRF-006, REQ-CSRF-007: default cap bumped from 1 MiB to 10 MB.
+    """
+    from core.auth.csrf import _form_body_cap
+
+    assert _form_body_cap() == 10 * 1024 * 1024
+
+    # A body slightly over old 1 MiB cap but under 10 MB must now be accepted
+    _nonce, cookie_val = _signed_cookie()
+    # 1.5 MB urlencoded body with the valid token appended
+    large_prefix = 'x=' + 'a' * (1_500_000 - 100)
+    token_part = f'&_csrf_token={cookie_val}'
+    body = (large_prefix + token_part).encode()
+    # Confirm body is between old cap (1 MiB) and new cap (10 MB)
+    assert 1 * 1024 * 1024 < len(body) < 10 * 1024 * 1024
+
+    scope = _scope_with_cookie('POST', 'csrftoken', cookie_val)
+    scope['headers'].append((b'content-type', b'application/x-www-form-urlencoded'))
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(body), cap.send)
+    # Must NOT be 413 — the new cap allows this size
+    assert cap.status == 200, f'Expected 200 (body within 10 MB cap) but got {cap.status}'
+
+
+@pytest.mark.asyncio
+async def test_form_body_cap_is_configurable(monkeypatch):
+    """CSRF_FORM_MAX_BODY_SIZE override works via config.get.
+
+    REQ-CSRF-006.
+    """
+    from core.auth import csrf as csrf_module
+
+    monkeypatch.setattr(csrf_module, '_form_body_cap', lambda: 256)
+    body = b'a' * 1024  # over the lowered cap
+    _nonce, cookie_val = _signed_cookie()
+    scope = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_val,
+        headers=[(b'content-type', b'application/x-www-form-urlencoded')],
+    )
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(body), cap.send)
+    assert cap.status == 413
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-005 — multipart refusal (INV-004 unchanged)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multipart_without_header_is_refused():
+    """Multipart bodies must NOT be buffered — clients must send X-CSRF-Token.
+
+    REQ-CSRF-005, INV-004.
+    """
+    _nonce, cookie_val = _signed_cookie()
+    body = (
+        b'------WebKitFormBoundary7MA4YWxk\r\n'
+        b'Content-Disposition: form-data; name="_csrf_token"\r\n'
+        b'\r\n' + cookie_val.encode() + b'\r\n------WebKitFormBoundary7MA4YWxk--\r\n'
+    )
+    scope = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_val,
+        headers=[(b'content-type', b'multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxk')],
+    )
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(body), cap.send)
+    assert cap.status == 403
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-006 — urlencoded form body paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_urlencoded_form_masked_token_validates():
+    """POST with urlencoded body containing _csrf_token = mask(cookie_value) -> 200.
+
+    REQ-CSRF-006, REQ-CSRF-003.
+    """
+    from core.auth.csrf import _mask
+
+    _nonce, cookie_val = _signed_cookie()
+    masked = _mask(cookie_val)
+    body = urlencode({'_csrf_token': masked}).encode()
+    scope = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_val,
+        headers=[(b'content-type', b'application/x-www-form-urlencoded')],
+    )
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(body), cap.send)
+    assert cap.status == 200
+
+
+@pytest.mark.asyncio
+async def test_urlencoded_form_missing_token_is_403():
+    """POST with urlencoded body without _csrf_token -> 403.
+
+    REQ-CSRF-006.
+    """
+    _nonce, cookie_val = _signed_cookie()
+    body = urlencode({'name': 'alice', 'age': '30'}).encode()
+    scope = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_val,
+        headers=[(b'content-type', b'application/x-www-form-urlencoded')],
+    )
+
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(body), cap.send)
+    assert cap.status == 403
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-008 — exempt paths and safe methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exempt_path_skips_validation():
+    """POST to an exempt path with no token -> 200 (no 403).
+
+    REQ-CSRF-008.
+    """
+    scope = _scope('POST', path='/api/webhook', content_type='application/x-www-form-urlencoded')
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app, exempt_paths=['/api/webhook'])
+    await mw(scope, await _make_receive(b'no_token=1'), cap.send)
+    assert cap.status == 200
+
+
+@pytest.mark.asyncio
+async def test_safe_method_passes_through():
+    """GET bypasses CSRF validation entirely.
+
+    REQ-CSRF-008.
+    """
+    scope = _scope('GET')
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+    assert cap.status == 200
+
+
+@pytest.mark.asyncio
+async def test_websocket_scope_passes_through():
+    """scope['type'] == 'websocket' -> passed through without CSRF logic.
+
+    REQ-CSRF-008.
+    """
     called = False
 
     async def ws_app(scope, receive, send):
@@ -327,47 +600,332 @@ async def test_non_http_scope_passes():
 
 
 # ---------------------------------------------------------------------------
-# No session -> 403
+# REQ-CSRF-004 — JSON content type without header -> 403
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_post_without_session_returns_403():
-    scope = _scope('POST', content_type='application/x-www-form-urlencoded')
-    # No session key in scope
+async def test_json_content_type_without_header_is_403():
+    """POST with Content-Type: application/json, no X-CSRF-Token -> 403 without reading body.
+
+    REQ-CSRF-004.
+    """
+    _nonce, cookie_val = _signed_cookie()
+    scope = _scope_with_cookie(
+        'POST',
+        'csrftoken',
+        cookie_val,
+        headers=[(b'content-type', b'application/json')],
+    )
+
+    body_read = {'count': 0}
+
+    async def tracking_receive():
+        body_read['count'] += 1
+        return {'type': 'http.request', 'body': b'{"key": "value"}', 'more_body': False}
+
     cap = _Captured()
     mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(b'_csrf_token=x'), cap.send)
+    await mw(scope, tracking_receive, cap.send)
     assert cap.status == 403
+    assert body_read['count'] == 0, 'Middleware must not read body for JSON without header'
 
 
 # ---------------------------------------------------------------------------
-# Body size limit -> 413
+# REQ-CSRF-001, REQ-CSRF-002 — cookie issuance via send-wrapper
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_large_body_returns_413():
-    # 1 MiB default cap + 1 byte. The cap is configurable via
-    # CSRF_FORM_MAX_BODY_SIZE; we test the default here.
-    large_body = b'a' * (1 * 1024 * 1024 + 1)
-    scope = _scope('POST', session={}, content_type='application/x-www-form-urlencoded')
+async def test_csrf_cookie_set_when_absent():
+    """GET with no CSRF cookie -> response Set-Cookie includes csrftoken={nonce}.{sig}
+    with a verifiable HMAC signature.
+
+    REQ-CSRF-001, REQ-CSRF-002.
+    """
+    scope = _scope('GET')
     cap = _Captured()
     mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(large_body), cap.send)
-    assert cap.status == 413
-    assert b'Too Large' in cap.body
+    await mw(scope, await _make_receive(), cap.send)
+
+    assert cap.status == 200
+    set_cookies = cap.set_cookie_headers()
+    assert set_cookies, 'Expected at least one Set-Cookie header on first GET'
+
+    csrf_cookie = next((c for c in set_cookies if 'csrftoken=' in c), None)
+    assert csrf_cookie is not None, f'No csrftoken Set-Cookie found; got: {set_cookies}'
+
+    # Extract the cookie value and verify its signature
+    cookie_val = csrf_cookie.split('csrftoken=')[1].split(';')[0].strip()
+    assert '.' in cookie_val, f'Cookie must be nonce.sig format; got: {cookie_val!r}'
+
+    nonce_part, sig_part = cookie_val.rsplit('.', 1)
+    import settings
+
+    expected_sig = hmac.new(settings.SECRET_KEY.encode(), nonce_part.encode(), 'sha256').hexdigest()
+    assert hmac.compare_digest(sig_part, expected_sig), 'Cookie signature must verify under SECRET_KEY'
 
 
 @pytest.mark.asyncio
-async def test_form_body_cap_is_configurable(monkeypatch):
-    """Setting CSRF_FORM_MAX_BODY_SIZE in config raises (or lowers) the cap."""
+async def test_csrf_cookie_not_reissued_when_present():
+    """GET with a valid signed CSRF cookie -> no new Set-Cookie for cookie name.
+
+    REQ-CSRF-001, Decision 3 (no rotation).
+    """
+    import settings
+
+    _nonce, cookie_val = _signed_cookie(secret=settings.SECRET_KEY)
+    scope = _scope_with_cookie('GET', 'csrftoken', cookie_val)
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+
+    assert cap.status == 200
+    csrf_set_cookies = [c for c in cap.set_cookie_headers() if 'csrftoken=' in c]
+    assert not csrf_set_cookies, (
+        f'Should NOT re-issue cookie when valid one is present; got Set-Cookie: {csrf_set_cookies}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_csrf_cookie_reissued_when_signature_invalid():
+    """GET with a cookie that fails signature check -> fresh valid cookie issued.
+
+    REQ-CSRF-001, REQ-CSRF-002: invalid cookie treated as absent.
+    """
+    nonce = Security.generate_csrf_token()
+    bad_sig = 'b' * 64
+    bad_cookie = f'{nonce}.{bad_sig}'
+    scope = _scope_with_cookie('GET', 'csrftoken', bad_cookie)
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+
+    assert cap.status == 200
+    csrf_set_cookies = [c for c in cap.set_cookie_headers() if 'csrftoken=' in c]
+    assert csrf_set_cookies, 'Must re-issue a fresh cookie when the existing one has an invalid signature'
+
+
+@pytest.mark.asyncio
+async def test_host_prefix_forces_secure_path_no_domain(monkeypatch):
+    """CSRF_COOKIE_NAME='__Host-csrftoken' -> Set-Cookie includes Secure; Path=/; no Domain=.
+
+    REQ-CSRF-001, Decision 4.
+    """
     from core.auth import csrf as csrf_module
 
-    monkeypatch.setattr(csrf_module, '_form_body_cap', lambda: 256)
-    body = b'a' * 1024  # over the lowered cap
-    scope = _scope('POST', session={}, content_type='application/x-www-form-urlencoded')
+    monkeypatch.setattr(csrf_module, '_cookie_name', lambda: '__Host-csrftoken')
+    monkeypatch.setattr(csrf_module, '_cookie_secure', lambda: True)
+    monkeypatch.setattr(csrf_module, '_cookie_samesite', lambda: 'Lax')
+    monkeypatch.setattr(csrf_module, '_cookie_httponly', lambda: False)
+    monkeypatch.setattr(csrf_module, '_cookie_path', lambda: '/')
+    monkeypatch.setattr(csrf_module, '_cookie_max_age', lambda: None)
+
+    scope = _scope('GET')
     cap = _Captured()
     mw = CsrfMiddleware(_passthrough_app)
-    await mw(scope, await _make_receive(body), cap.send)
-    assert cap.status == 413
+    await mw(scope, await _make_receive(), cap.send)
+
+    csrf_set_cookies = [c for c in cap.set_cookie_headers() if '__Host-csrftoken=' in c]
+    assert csrf_set_cookies, 'Expected __Host-csrftoken Set-Cookie header'
+    cookie_str = csrf_set_cookies[0]
+
+    assert 'Secure' in cookie_str, f'__Host- cookie must have Secure; got: {cookie_str!r}'
+    assert 'Path=/' in cookie_str, f'__Host- cookie must have Path=/; got: {cookie_str!r}'
+    assert 'Domain=' not in cookie_str, f'__Host- cookie must NOT have Domain=; got: {cookie_str!r}'
+
+
+@pytest.mark.asyncio
+async def test_host_prefix_insecure_logs_warning_once(monkeypatch):
+    """__Host- cookie name + CSRF_COOKIE_SECURE False -> exactly one log.warning.
+
+    Design §5, Decision 4: the misconfiguration must be LOUD. The middleware still
+    force-secures the cookie (in addition to the warning, not instead). The warning
+    fires once per process via the _host_prefix_warned guard.
+    """
+    import logging
+
+    from core.auth import csrf as csrf_module
+
+    # __Host- name with the operator explicitly (mis)configuring SECURE False.
+    # config is a slotted singleton, so swap the whole config reference for a stub.
+    _overrides = {
+        'CSRF_COOKIE_NAME': '__Host-csrftoken',
+        'CSRF_COOKIE_SECURE': False,
+    }
+
+    class _StubConfig:
+        SECRET_KEY = __import__('settings').SECRET_KEY
+
+        def get(self, key, default=None):
+            return _overrides.get(key, default)
+
+    monkeypatch.setattr(csrf_module, 'config', _StubConfig())
+    # Reset the one-time guard so this test observes the first emission.
+    monkeypatch.setattr(csrf_module, '_host_prefix_warned', False)
+
+    # The 'nori' parent logger sets propagate=False, so caplog (rooted at the root
+    # logger) never sees these child records. Attach our own capturing handler
+    # directly to the 'nori.csrf' logger instead.
+    captured_records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record):
+            captured_records.append(record)
+
+    csrf_logger = logging.getLogger('nori.csrf')
+    handler = _ListHandler(level=logging.WARNING)
+    csrf_logger.addHandler(handler)
+
+    async def _issue_cookie():
+        scope = _scope('GET')
+        cap = _Captured()
+        mw = CsrfMiddleware(_passthrough_app)
+        await mw(scope, await _make_receive(), cap.send)
+        return cap
+
+    try:
+        # Two issuances — the warning must fire on the FIRST only.
+        cap1 = await _issue_cookie()
+        await _issue_cookie()  # second issuance — warning must NOT fire again
+    finally:
+        csrf_logger.removeHandler(handler)
+
+    host_warnings = [
+        r
+        for r in captured_records
+        if r.levelno == logging.WARNING and '__Host-' in r.getMessage() and 'CSRF_COOKIE_SECURE' in r.getMessage()
+    ]
+    assert len(host_warnings) == 1, f'__Host-/insecure warning must fire exactly once; fired {len(host_warnings)} times'
+
+    # The cookie is STILL force-secured (warning is in addition, not instead).
+    issued = [c for c in cap1.set_cookie_headers() if '__Host-csrftoken=' in c]
+    assert issued and 'Secure' in issued[0], 'cookie must be force-secured despite the warning'
+
+
+@pytest.mark.asyncio
+async def test_samesite_default_is_lax():
+    """No CSRF_COOKIE_SAMESITE setting -> cookie SameSite=Lax.
+
+    REQ-CSRF-013.
+    """
+    scope = _scope('GET')
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+
+    csrf_set_cookies = [c for c in cap.set_cookie_headers() if 'csrftoken=' in c]
+    assert csrf_set_cookies, 'Expected Set-Cookie header'
+    assert 'SameSite=Lax' in csrf_set_cookies[0], f'Default SameSite must be Lax; got: {csrf_set_cookies[0]!r}'
+
+
+@pytest.mark.asyncio
+async def test_pending_cookie_seeded_in_scope_before_handler():
+    """On first GET (no cookie), scope['csrf_pending_cookie'] is set before the inner app runs.
+
+    REQ-CSRF-009, design §7 first-request coordination.
+    """
+    scope = _scope('GET')
+    pending_seen: list[str] = []
+
+    async def capturing_app(scope, receive, send):
+        val = scope.get('csrf_pending_cookie', '')
+        pending_seen.append(val)
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b'OK'})
+
+    mw = CsrfMiddleware(capturing_app)
+    await mw(scope, await _make_receive(), _Captured().send)
+
+    assert pending_seen, 'Inner app was never called'
+    assert pending_seen[0], 'csrf_pending_cookie must be set before the handler runs'
+    # Verify the pending value has the correct signed structure
+    pending = pending_seen[0]
+    assert '.' in pending, f'Pending cookie must be nonce.sig; got: {pending!r}'
+
+
+@pytest.mark.asyncio
+async def test_settings_default_cookie_name():
+    """No CSRF_COOKIE_NAME in settings -> uses 'csrftoken' without AttributeError.
+
+    REQ-CSRF-013, INV-029.
+    """
+    scope = _scope('GET')
+    cap = _Captured()
+    mw = CsrfMiddleware(_passthrough_app)
+    await mw(scope, await _make_receive(), cap.send)
+
+    assert cap.status == 200
+    csrf_set_cookies = [c for c in cap.set_cookie_headers() if c.startswith('csrftoken=')]
+    assert csrf_set_cookies, 'Default cookie name must be csrftoken'
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-009, REQ-CSRF-010 — csrf_field and csrf_token helpers (jinja tests)
+# ---------------------------------------------------------------------------
+
+
+def test_csrf_field_accepts_request():
+    """csrf_field(request) reads request.cookies[CSRF_COOKIE_NAME] and emits a masked input.
+
+    REQ-CSRF-009.
+    """
+    _nonce, cookie_val = _signed_cookie()
+
+    class _FakeRequest:
+        cookies = {'csrftoken': cookie_val}
+        scope: dict = {}
+
+    html = csrf_field(_FakeRequest())
+    assert 'name="_csrf_token"' in html
+    assert '<input' in html
+    # The value should NOT be the raw cookie (it should be masked)
+    assert f'value="{cookie_val}"' not in html, 'csrf_field must return a masked value, not the raw cookie'
+
+
+def test_csrf_field_uses_pending_cookie_when_no_cookie():
+    """First GET: scope['csrf_pending_cookie'] set -> csrf_field returns masked form of that value.
+
+    REQ-CSRF-009.
+    """
+    _nonce, cookie_val = _signed_cookie()
+
+    class _FakeRequest:
+        cookies: dict = {}  # no cookie in request
+        scope = {'csrf_pending_cookie': cookie_val}
+
+    html = csrf_field(_FakeRequest())
+    assert 'name="_csrf_token"' in html
+    assert html != '<input type="hidden" name="_csrf_token" value="">', (
+        'On first request, csrf_field must use scope[csrf_pending_cookie], not return empty'
+    )
+
+
+def test_csrf_token_returns_raw_cookie_value():
+    """csrf_token(request) returns the full {nonce}.{sig} string verbatim.
+
+    REQ-CSRF-010.
+    """
+    _nonce, cookie_val = _signed_cookie()
+
+    class _FakeRequest:
+        cookies = {'csrftoken': cookie_val}
+        scope: dict = {}
+
+    result = csrf_token(_FakeRequest())
+    assert result == cookie_val, f'csrf_token must return the raw cookie value; got {result!r}'
+
+
+def test_csrf_token_returns_pending_cookie_on_first_visit():
+    """No cookie, scope['csrf_pending_cookie'] set -> csrf_token returns that value.
+
+    REQ-CSRF-010.
+    """
+    _nonce, cookie_val = _signed_cookie()
+
+    class _FakeRequest:
+        cookies: dict = {}
+        scope = {'csrf_pending_cookie': cookie_val}
+
+    result = csrf_token(_FakeRequest())
+    assert result == cookie_val

--- a/tests/test_core/test_jinja.py
+++ b/tests/test_core/test_jinja.py
@@ -1,4 +1,11 @@
-"""Tests for core.jinja template globals."""
+"""Tests for core.jinja template globals.
+
+WU-1 additions: RED tests for csrf_field(request) and csrf_token(request)
+signatures. These will fail against the session-based implementation and pass
+after WU-2.
+"""
+
+from __future__ import annotations
 
 from core.jinja import templates
 
@@ -21,3 +28,154 @@ def test_csrf_field_callable():
 def test_get_flashed_messages_callable():
     """The registered get_flashed_messages should be callable."""
     assert callable(templates.env.globals['get_flashed_messages'])
+
+
+# ---------------------------------------------------------------------------
+# RED tests — new request-accepting signature (WU-1)
+# REQ-CSRF-009, REQ-CSRF-010
+# ---------------------------------------------------------------------------
+
+
+def test_csrf_field_accepts_request():
+    """csrf_field(request) reads request.cookies and emits a masked hidden input.
+
+    REQ-CSRF-009: the function accepts a request object, not a session dict.
+    """
+    import hmac
+
+    from core.auth.csrf import csrf_field
+    from core.auth.security import Security
+
+    nonce = Security.generate_csrf_token()
+    import settings
+
+    sig = hmac.new(settings.SECRET_KEY.encode(), nonce.encode(), 'sha256').hexdigest()
+    cookie_val = f'{nonce}.{sig}'
+
+    class _FakeRequest:
+        cookies = {'csrftoken': cookie_val}
+        scope: dict = {}
+
+    html = csrf_field(_FakeRequest())
+    assert 'name="_csrf_token"' in html
+    assert '<input' in html
+    # Value must be the BREACH-masked form, not the raw cookie value
+    assert f'value="{cookie_val}"' not in html, (
+        'csrf_field(request) must return a masked token, not the raw cookie value'
+    )
+
+
+def test_csrf_field_uses_pending_cookie_when_no_cookie():
+    """On first GET (no cookie), csrf_field uses scope['csrf_pending_cookie'].
+
+    REQ-CSRF-009: first-request coordination via scope seam.
+    """
+    import hmac
+
+    import settings
+    from core.auth.csrf import csrf_field
+    from core.auth.security import Security
+
+    nonce = Security.generate_csrf_token()
+    sig = hmac.new(settings.SECRET_KEY.encode(), nonce.encode(), 'sha256').hexdigest()
+    cookie_val = f'{nonce}.{sig}'
+
+    class _FakeRequest:
+        cookies: dict = {}  # no cookie in request
+        scope = {'csrf_pending_cookie': cookie_val}
+
+    html = csrf_field(_FakeRequest())
+    assert 'name="_csrf_token"' in html
+    assert html != '<input type="hidden" name="_csrf_token" value="">', (
+        'csrf_field must use scope[csrf_pending_cookie] when no cookie is present'
+    )
+
+
+def test_csrf_token_returns_raw_cookie_value():
+    """csrf_token(request) returns the raw {nonce}.{sig} verbatim (not masked, not HMAC-only).
+
+    REQ-CSRF-010.
+    """
+    import hmac
+
+    import settings
+    from core.auth.csrf import csrf_token
+    from core.auth.security import Security
+
+    nonce = Security.generate_csrf_token()
+    sig = hmac.new(settings.SECRET_KEY.encode(), nonce.encode(), 'sha256').hexdigest()
+    cookie_val = f'{nonce}.{sig}'
+
+    class _FakeRequest:
+        cookies = {'csrftoken': cookie_val}
+        scope: dict = {}
+
+    result = csrf_token(_FakeRequest())
+    assert result == cookie_val, f'csrf_token(request) must return the raw cookie value {cookie_val!r}; got {result!r}'
+
+
+def test_csrf_token_returns_pending_cookie_on_first_visit():
+    """No cookie + scope['csrf_pending_cookie'] -> csrf_token returns that value.
+
+    REQ-CSRF-010.
+    """
+    import hmac
+
+    import settings
+    from core.auth.csrf import csrf_token
+    from core.auth.security import Security
+
+    nonce = Security.generate_csrf_token()
+    sig = hmac.new(settings.SECRET_KEY.encode(), nonce.encode(), 'sha256').hexdigest()
+    cookie_val = f'{nonce}.{sig}'
+
+    class _FakeRequest:
+        cookies: dict = {}
+        scope = {'csrf_pending_cookie': cookie_val}
+
+    result = csrf_token(_FakeRequest())
+    assert result == cookie_val
+
+
+# ---------------------------------------------------------------------------
+# REQ-CSRF-012, design §5 — custom CSRF_COOKIE_NAME reaches base.html so the
+# JS shim reads it from window.NORI_CSRF_COOKIE_NAME (no hard-coded name).
+# ---------------------------------------------------------------------------
+
+
+def test_csrf_cookie_name_global_is_registered():
+    """csrf_cookie_name is exposed as a Jinja global for base.html to render."""
+    assert 'csrf_cookie_name' in templates.env.globals
+    assert callable(templates.env.globals['csrf_cookie_name'])
+
+
+def test_custom_csrf_cookie_name_reaches_rendered_base_html(monkeypatch):
+    """A custom CSRF_COOKIE_NAME (e.g. __Host-csrftoken) is rendered into base.html's
+    window.NORI_CSRF_COOKIE_NAME global, BEFORE the csrf.js include.
+
+    Pins Finding 2: the shim no longer hard-codes 'csrftoken' — base.html renders the
+    configured name so the shim tracks the operator's __Host-csrftoken choice.
+    """
+    from core.auth import csrf as csrf_module
+
+    monkeypatch.setattr(csrf_module, '_cookie_name', lambda: '__Host-csrftoken')
+
+    template = templates.env.get_template('base.html')
+    rendered = template.render(request=type('R', (), {'session': {}})())
+
+    # The configured name appears in the rendered global assignment.
+    assert '__Host-csrftoken' in rendered
+    assert 'window.NORI_CSRF_COOKIE_NAME' in rendered
+
+    # The global is rendered BEFORE the csrf.js include so it is set when the shim runs.
+    global_pos = rendered.index('window.NORI_CSRF_COOKIE_NAME')
+    include_pos = rendered.index('<script src="/static/js/csrf.js"')
+    assert global_pos < include_pos, 'window.NORI_CSRF_COOKIE_NAME must be rendered before the csrf.js include'
+
+
+def test_default_csrf_cookie_name_reaches_rendered_base_html():
+    """With no override, base.html renders the default 'csrftoken' name."""
+    template = templates.env.get_template('base.html')
+    rendered = template.render(request=type('R', (), {'session': {}})())
+    assert '"csrftoken"' in rendered
+    assert 'window.NORI_CSRF_COOKIE_NAME' in rendered


### PR DESCRIPTION
Closes #29.

## v2.0.0 — Signed double-submit CSRF cookie

Replaces Nori's session-bound CSRF synchronizer token with an **OWASP signed double-submit cookie**, fixing the full-page-cache 403 reported in #29: a `cache_response` page no longer embeds a per-session token that mismatches the next visitor.

**Breaking change → v2.0.0.** `csrf_field(request.session)` → `csrf_field(request)`; session-bound CSRF removed; new `CSRF_COOKIE_*` settings. See `docs/upgrade-2.0.md`.

### Design

- Cookie value IS the submitted token: `{nonce}.{sig}`, `sig = HMAC-SHA256(SECRET_KEY, nonce)`. Validation = two constant-time checks — (1) cookie-signature integrity, (2) double-submit equality (accepts the raw value from the JS shim/`X-CSRF-Token` header, or the BREACH-masked value from `csrf_field`).
- The signature defeats the cookie-**writer** attacker (subdomain/DNS); same-origin policy defeats the cross-site attacker; XSS is out of scope (it defeats any CSRF defense).
- **Invariant (INV-030):** `cache_response` MUST NOT cache `Set-Cookie` — the CSRF cookie stays per-visitor. Pinned by a regression test.
- BREACH masking (per-render XOR, stdlib). Body cap 1 MiB → **10 MB** to match the docs (closes a standing INV-015 mismatch).

### What's in here

- **Core**: `csrf.py` rewrite, cookie issuance via ASGI send-wrapper, `csrf_field(request)`/`csrf_token(request)`, 6 `CSRF_COOKIE_*` settings (via `config.get`, INV-029), `static/js/csrf.js` shim + `base.html` include.
- **Docs** (INV-015 coherence, every value verified against code): security/middleware/architecture/controllers rewrite, **INV-030** + INV-004 update, `docs/upgrade-2.0.md`, CHANGELOG v2.0.0.
- **Tests**: full signed-double-submit suite incl. writer-attack, dual-accept, cross-visitor cached-page + shim, Set-Cookie-never-cached.

### Review trail

- Built via SDD (explore → propose → spec → design → tasks → apply → verify). The wire format survived an adversarial design revision (a first variant required caching `Set-Cookie`, sharing one nonce across cached-page visitors — a CSRF bypass — rejected).
- **judgment-day: APPROVED after 3 rounds.** Round 2 caught a request-triggerable `TypeError`/DoS in token comparison (non-ASCII unmask hitting `hmac.compare_digest` on `str`); fixed via bytes comparison.
- **sdd-verify: PASS** — 17/17 requirements implemented + tested, no drift.
- Local gates (CI runs here for the first time on the full change): ruff, ruff format, mypy, interrogate, semgrep custom (0), **pytest 1063 passed, coverage 90.59%**.

> Delivered via feature-branch-chain: PR #30 (core) and #31 (docs) merged into this tracker branch; this PR brings the consolidated change to `main`.
