### PR TITLE
fix(cli): consolidate aerich config into a single root pyproject.toml (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ When a release is cut, rename `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD` and see
 
 ## [Unreleased]
 
-_Nothing accumulated yet — add entries here as they ship to `main` so the next release cut is just a rename + date stamp._
+### Changed
+
+- **Single `pyproject.toml` per project ([#22](https://github.com/sembeimx/nori/issues/22))**: the aerich config (`[tool.aerich]`) now lives in the root `pyproject.toml` alongside ruff/mypy/coverage/interrogate, so a new Nori project ships **one** `pyproject.toml` instead of two. The CLI passes `aerich -c <root-pyproject>` to every `migrate:*` command; `location` stays relative to the migrations' working directory, so existing migrations are unaffected.
+  - **Existing projects**: nothing breaks. The CLI prefers the root `[tool.aerich]` but transparently falls back to the legacy `rootsystem/application/pyproject.toml` when the root lacks it. To consolidate, move `[tool.aerich]` into your root `pyproject.toml` and delete `rootsystem/application/pyproject.toml`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,3 +206,10 @@ exclude_lines = [
     # Defensive guards in CLI subprocess scripts that only run in error paths.
     "raise AssertionError",
 ]
+
+[tool.aerich]
+# Consolidated here (issue #22) so a Nori project ships a single pyproject.toml.
+# `location` is resolved relative to the CLI's working directory
+# (rootsystem/application/), so migrations live at rootsystem/application/migrations/.
+tortoise_orm = "settings.TORTOISE_ORM"
+location = "./migrations"

--- a/rootsystem/application/core/cli.py
+++ b/rootsystem/application/core/cli.py
@@ -264,10 +264,35 @@ def _read_tortoise_apps() -> tuple[str, ...]:
     return apps or _DEFAULT_APPS
 
 
+def _has_aerich_table(path: str) -> bool:
+    """True if the TOML file at ``path`` declares a ``[tool.aerich]`` table."""
+    try:
+        with open(path, encoding='utf-8') as fh:
+            # Strip any inline comment before matching so `[tool.aerich]  # note`
+            # still resolves; a commented-out `# [tool.aerich]` correctly does not.
+            return any(line.split('#', 1)[0].strip() == '[tool.aerich]' for line in fh)
+    except OSError:
+        return False
+
+
+def _aerich_config() -> str:
+    """Resolve the pyproject.toml carrying ``[tool.aerich]``, to pass via aerich ``-c``.
+
+    Prefers the consolidated root ``pyproject.toml`` (Nori 2.1+). Falls back to the
+    legacy in-app ``rootsystem/application/pyproject.toml`` for projects that upgraded
+    before the consolidation and still carry it. Both paths derive from ``_APP_DIR``
+    (anchored to this module via ``__file__``), so resolution is CWD-independent.
+    """
+    app_dir = pathlib.Path(_APP_DIR)
+    root = str(app_dir.parent.parent / 'pyproject.toml')
+    legacy = str(app_dir / 'pyproject.toml')
+    return root if _has_aerich_table(root) else legacy
+
+
 def migrate_init() -> None:
     print('Initializing Aerich migrations...')
     subprocess.run(
-        [sys.executable, '-m', 'aerich', 'init', '-t', 'settings.TORTOISE_ORM'],
+        [sys.executable, '-m', 'aerich', '-c', _aerich_config(), 'init', '-t', 'settings.TORTOISE_ORM'],
         cwd=_APP_DIR,
         env=_quiet_env(),
     )
@@ -286,7 +311,7 @@ def migrate_init() -> None:
             continue
         print(f"  Generating initial migrations and tables for app '{app}'...")
         subprocess.run(
-            [sys.executable, '-m', 'aerich', '--app', app, 'init-db'],
+            [sys.executable, '-m', 'aerich', '-c', _aerich_config(), '--app', app, 'init-db'],
             cwd=_APP_DIR,
             env=_quiet_env(),
         )
@@ -295,7 +320,7 @@ def migrate_init() -> None:
 def migrate_make(name: str, app: str = 'models') -> None:
     print(f'Creating migration: {name} (app: {app})...')
     subprocess.run(
-        [sys.executable, '-m', 'aerich', '--app', app, 'migrate', '--name', name],
+        [sys.executable, '-m', 'aerich', '-c', _aerich_config(), '--app', app, 'migrate', '--name', name],
         cwd=_APP_DIR,
         env=_quiet_env(),
     )
@@ -306,7 +331,7 @@ def migrate_upgrade(app: str | None = None) -> None:
     for a in apps:
         print(f'Running migrations (upgrade) for app: {a}...')
         subprocess.run(
-            [sys.executable, '-m', 'aerich', '--app', a, 'upgrade'],
+            [sys.executable, '-m', 'aerich', '-c', _aerich_config(), '--app', a, 'upgrade'],
             cwd=_APP_DIR,
             env=_quiet_env(),
         )
@@ -314,7 +339,7 @@ def migrate_upgrade(app: str | None = None) -> None:
 
 def migrate_downgrade(steps: int = 1, delete: bool = False, app: str = 'models') -> None:
     print(f'Rolling back {steps} migration(s) for app: {app}...')
-    cmd = [sys.executable, '-m', 'aerich', '--app', app, 'downgrade', '-v', str(steps)]
+    cmd = [sys.executable, '-m', 'aerich', '-c', _aerich_config(), '--app', app, 'downgrade', '-v', str(steps)]
     if delete:
         cmd.append('-d')
     subprocess.run(cmd, cwd=_APP_DIR, env=_quiet_env())
@@ -323,7 +348,7 @@ def migrate_downgrade(steps: int = 1, delete: bool = False, app: str = 'models')
 def migrate_fix() -> None:
     print('Fixing migration files to current Aerich format...')
     subprocess.run(
-        [sys.executable, '-m', 'aerich', 'fix-migrations'],
+        [sys.executable, '-m', 'aerich', '-c', _aerich_config(), 'fix-migrations'],
         cwd=_APP_DIR,
         env=_quiet_env(),
     )

--- a/rootsystem/application/pyproject.toml
+++ b/rootsystem/application/pyproject.toml
@@ -1,3 +1,0 @@
-[tool.aerich]
-tortoise_orm = "settings.TORTOISE_ORM"
-location = "./migrations"

--- a/tests/test_core/test_cli.py
+++ b/tests/test_core/test_cli.py
@@ -275,6 +275,75 @@ def test_migrate_downgrade_omits_delete_flag_by_default():
 
 
 # ---------------------------------------------------------------------------
+# aerich config resolution (issue #22 — single root pyproject.toml)
+# ---------------------------------------------------------------------------
+
+
+def _make_aerich_project(tmp_path, *, root_has_aerich: bool, legacy_exists: bool = True):
+    """Build a fake project tree and return (app_dir, root_pyproject, legacy)."""
+    app_dir = tmp_path / 'proj' / 'rootsystem' / 'application'
+    app_dir.mkdir(parents=True)
+    aerich_table = '[tool.aerich]\ntortoise_orm = "settings.TORTOISE_ORM"\nlocation = "./migrations"\n'
+    root_pyproject = tmp_path / 'proj' / 'pyproject.toml'
+    root_pyproject.write_text('[tool.ruff]\n' + (aerich_table if root_has_aerich else ''))
+    legacy = app_dir / 'pyproject.toml'
+    if legacy_exists:
+        legacy.write_text(aerich_table)
+    return str(app_dir), str(root_pyproject), str(legacy)
+
+
+def test_has_aerich_table_detects_presence_absence_and_missing(tmp_path):
+    present = tmp_path / 'a.toml'
+    present.write_text('[tool.ruff]\n[tool.aerich]\nlocation = "./migrations"\n')
+    absent = tmp_path / 'b.toml'
+    absent.write_text('[tool.ruff]\nline-length = 100\n')
+    inline_comment = tmp_path / 'c.toml'
+    inline_comment.write_text('[tool.aerich]  # consolidated\nlocation = "./migrations"\n')
+    commented_out = tmp_path / 'd.toml'
+    commented_out.write_text('# [tool.aerich]\n[tool.ruff]\n')
+    assert cli._has_aerich_table(str(present)) is True
+    assert cli._has_aerich_table(str(inline_comment)) is True
+    assert cli._has_aerich_table(str(absent)) is False
+    assert cli._has_aerich_table(str(commented_out)) is False
+    assert cli._has_aerich_table(str(tmp_path / 'missing.toml')) is False
+
+
+def test_aerich_config_prefers_root_when_it_has_table(tmp_path, monkeypatch):
+    app_dir, root_pyproject, _legacy = _make_aerich_project(tmp_path, root_has_aerich=True)
+    monkeypatch.setattr(cli, '_APP_DIR', app_dir)
+    assert cli._aerich_config() == root_pyproject
+
+
+def test_aerich_config_falls_back_to_legacy_when_root_lacks_table(tmp_path, monkeypatch):
+    app_dir, _root, legacy = _make_aerich_project(tmp_path, root_has_aerich=False)
+    monkeypatch.setattr(cli, '_APP_DIR', app_dir)
+    assert cli._aerich_config() == legacy
+
+
+def test_migrate_commands_pass_dash_c_config(migrations_env):
+    """Every aerich invocation must carry `-c <config>` (issue #22)."""
+    expected = cli._aerich_config()
+    cases = [
+        (cli.migrate_init, ()),
+        (cli.migrate_make, ('x',)),
+        (cli.migrate_upgrade, ()),
+        (cli.migrate_downgrade, ()),
+        (cli.migrate_fix, ()),
+    ]
+    for fn, args in cases:
+        with patch('subprocess.run') as mock_run:
+            fn(*args)
+        aerich_calls = [c for c in mock_run.call_args_list if 'aerich' in c.args[0]]
+        assert aerich_calls, f'{fn.__name__} ran no aerich call'
+        for call in aerich_calls:
+            argv = call.args[0]
+            assert _aerich_arg(call, '-c') == expected, f'{fn.__name__} missing -c'
+            # -c is a top-level aerich option and MUST precede the subcommand;
+            # the code places it immediately after 'aerich'.
+            assert argv[argv.index('aerich') + 1] == '-c', f'{fn.__name__} -c not before subcommand'
+
+
+# ---------------------------------------------------------------------------
 # User commands — discovery must be CWD-independent
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #22.

## What

A Nori project shipped **two** `pyproject.toml` files — the root one (ruff/mypy/coverage/interrogate) and `rootsystem/application/pyproject.toml` holding three lines of `[tool.aerich]`. The second existed only because aerich's CLI reads `pyproject.toml` from its working directory (`cwd=_APP_DIR`). This consolidates to **one** `pyproject.toml`.

- `[tool.aerich]` moved into the root `pyproject.toml`; the in-app file is deleted.
- All 6 `aerich` subprocess calls in `core/cli.py` now pass `-c <root-pyproject>`.
- `location` stays `"./migrations"` — aerich resolves it relative to **cwd** (`_APP_DIR`), not the config dir, so migrations still live at `rootsystem/application/migrations/{app}`. **No migration path change, no data movement.**

## Empirical verification (issue mandated it)

- Read aerich 0.9.2's source: `Path(location, app)` is CWD-relative; `-c` only changes where the config is **read**. Confirmed with a repro (config outside cwd → migrations still landed under cwd).
- Ran real-aerich **end-to-end** with `-c` pointing at the root pyproject outside cwd: `init` → `init-db` → `migrate:make` (new column) → `upgrade` (column applied to DB) → `fix-migrations` — all succeeded, migrations landed cwd-relative, config stayed only in the root.

## Upgrade safety (existing projects)

Chosen strategy: a **resilient resolver**, not new `framework:update` deletion semantics. `_aerich_config()` prefers the root `[tool.aerich]` but transparently falls back to the legacy in-app `pyproject.toml` when the root lacks it. So an existing project that pulls the new `cli.py` keeps working unchanged; to consolidate, the user moves `[tool.aerich]` to their root pyproject and deletes the in-app file (documented in CHANGELOG). `framework:update` is untouched.

## Tests & gates

- 4 new tests (strict TDD): resolver prefers-root / falls-back-to-legacy, `_has_aerich_table` (presence / absence / inline-comment / commented-out / missing-file), and a guard that every `migrate:*` argv carries `-c` **before** the subcommand. Full suite **1073 passed**. Local gates green: ruff, mypy.
- Fresh-context adversarial review: **APPROVE-WITH-NITS** (both nits — inline-comment robustness in `_has_aerich_table`, and the `-c`-position assertion — applied in this PR).

Note: `framework:check-config` will list `tool.aerich` as "added upstream" for un-migrated projects during the transition window — expected/informational, not a defect.
